### PR TITLE
Placeholder for upcoming 2.11 overview

### DIFF
--- a/overviews/core/_posts/2014-03-14-scala-2.11.md
+++ b/overviews/core/_posts/2014-03-14-scala-2.11.md
@@ -1,0 +1,17 @@
+---
+layout: overview
+title: Scala 2.11
+label-text: New in Scala 2.11
+overview: scala-2.11
+---
+
+## What's new in Scala 2.11
+TODO: we'll have a migration guide here before 2.11 goes final.
+In the mean time, see the RC1 release notes: http://www.scala-lang.org/news/2014/03/06/release-notes-2.11.0-RC1.html
+
+### Modularization
+<!-- The compiler links to this heading as http://docs.scala-lang.org/overviews/core/scala-2.11.html#scala-xml -->
+#### scala-xml
+The package scala.xml has been moved out of scala-library.jar.
+To compile code that contains XML literals, add a dependency on scala-xml or your preferred alternative.
+


### PR DESCRIPTION
Adding a placeholder for the compiler to link to in an error message (see https://github.com/scala/scala/pull/3631)