### PR TITLE
Fixed newline typo in automatic-closures.md

### DIFF
--- a/tutorials/tour/automatic-closures.md
+++ b/tutorials/tour/automatic-closures.md
@@ -48,6 +48,7 @@ Here is the implementation of a loop-unless statement:
         i -= 1
       } unless (i == 0)
     }
+
 The `loop` function just accepts a body of a loop and returns an instance of class `LoopUnlessCond` (which encapsulates this body object). Note that the body didn't get evaluated yet. Class `LoopUnlessCond` has a method `unless` which we can use as a *infix operator*. This way, we achieve a quite natural syntax for our new loop: `loop { < stats > } unless ( < cond > )`.
 
 Here's the output when `TargetTest2` gets executed:


### PR DESCRIPTION
There was a newline character missing which resulted in the following output: https://imgur.com/Q2CAMtk,T9UbfHL#1
The `es` and `ko` versions of the document seem to be free of this issue.