### PR TITLE
updates to paradise 2.1.0-M4

### DIFF
--- a/ja/overviews/macros/paradise.md
+++ b/ja/overviews/macros/paradise.md
@@ -41,7 +41,7 @@ title: マクロパラダイス
 
     resolvers += Resolver.sonatypeRepo("releases")
 
-    addCompilerPlugin("org.scalamacros" % "paradise" % "2.0.1" cross CrossVersion.full)
+    addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0-M4" cross CrossVersion.full)
 
 マクロパラダイスを Maven から利用するには、Stack Overflow の [Enabling the macro-paradise Scala compiler plugin in Maven projects](http://stackoverflow.com/questions/19086241/enabling-the-macro-paradise-scala-compiler-plugin-in-maven-projects) に書かれた手順に従ってほしい。
 (Sonatype snapshots と `scala-reflect.jar` への依存性を追加することにも注意)
@@ -50,7 +50,7 @@ title: マクロパラダイス
       <compilerPlugin>
         <groupId>org.scalamacros</groupId>
         <artifactId>paradise_<YOUR.SCALA.VERSION></artifactId>
-        <version>2.0.1</version>
+        <version>2.1.0-M4</version>
       </compilerPlugin>
     </compilerPlugins>
 

--- a/overviews/macros/paradise.md
+++ b/overviews/macros/paradise.md
@@ -43,7 +43,7 @@ to your build (granted you’ve already [set up SBT](/overviews/macros/overview.
 to use macros).
 
     resolvers += Resolver.sonatypeRepo("releases")
-    addCompilerPlugin("org.scalamacros" % "paradise" % "2.0.1" cross CrossVersion.full)
+    addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0-M4" cross CrossVersion.full)
 
 To use macro paradise in Maven follow the instructions provided at Stack Overflow on the page ["Enabling the macro-paradise Scala compiler plugin in Maven projects"](http://stackoverflow.com/questions/19086241/enabling-the-macro-paradise-scala-compiler-plugin-in-maven-projects) (also make sure to add the dependency on the Sonatype snapshots repository and `scala-reflect.jar`).
 
@@ -51,7 +51,7 @@ To use macro paradise in Maven follow the instructions provided at Stack Overflo
       <compilerPlugin>
         <groupId>org.scalamacros</groupId>
         <artifactId>paradise_<YOUR.SCALA.VERSION></artifactId>
-        <version>2.0.1</version>
+        <version>2.1.0-M4</version>
       </compilerPlugin>
     </compilerPlugins>
 


### PR DESCRIPTION
Even though paradise 2.1.0 is still in milestone mode, I don't think
it's wise to advertise 2.0.x series any longer. Too many important fixes
have been made on 2.1.0.

Ideally, I'd release 2.0.2 with all those fixes backported. This brings us
to two simultaneously developed project families, which doesn't look like a lot.
Unfortunately, in reality we have to multiply everything by 8 (because
I'd like to maintain aradise for all minor versions of 2.10.x and 2.11.x),
and that would quickly become unwieldy.