### PR TITLE
Update links on overviews page to point to the correct scaladoc pages.

### DIFF
--- a/overviews/index.md
+++ b/overviews/index.md
@@ -36,8 +36,8 @@ languages: [es, ja]
 </div>
   * Scaladoc
     * [Overview](/overviews/scaladoc/overview.html)
-    * [Basics](/overviews/scaladoc/basics.html)
-    * [Using Scaladoc Effectively](/overviews/scaladoc/usage.html)
+    * [Using Scaladoc Effectively](/overviews/scaladoc/interface.html)
+    * [Authoring Scaladoc](/overviews/scaladoc/for-library-authors.html)
 
 <div class="page-header-index">
   <h2>Parallel and Concurrent Programming</h2>


### PR DESCRIPTION
Links to Using and Authoring Scaladoc were incorrect after recent tweaks, so updated them. Also changed the order (using before authoring) and the descriptions to be better.

Review by @heathermiller please