### PR TITLE
updated syntax from "future{ ... }" (deprecated) to "Future{ ... }" in the examples

### DIFF
--- a/overviews/core/_posts/2012-09-20-futures.md
+++ b/overviews/core/_posts/2012-09-20-futures.md
@@ -75,12 +75,12 @@ a request to obtain a list of friends of a particular user:
     import ExecutionContext.Implicits.global
     
     val session = socialNetwork.createSessionFor("user", credentials)
-    val f: Future[List[Friend]] = future {
+    val f: Future[List[Friend]] = Future {
       session.getFriends()
     }
 
 Above, we first import the contents of the `scala.concurrent` package
-to make the type `Future` and the construct `future` visible.
+to make the type `Future` and the construct `Future` visible.
 We will explain the second import shortly.
 
 We then initialize a session variable which we will use to send
@@ -104,7 +104,7 @@ initialized, so the computation in the `future` block will throw a `NullPointerE
 This future `f` is then failed with this exception instead of being completed successfully:
 	
     val session = null
-    val f: Future[List[Friend]] = future {
+    val f: Future[List[Friend]] = Future {
       session.getFriends
     }
 
@@ -128,7 +128,7 @@ This computation may involve blocking while the file contents
 are being retrieved from the disk, so it makes sense to perform it
 concurrently with the rest of the computation.
 
-    val firstOccurrence: Future[Int] = future {
+    val firstOccurrence: Future[Int] = Future {
       val source = scala.io.Source.fromFile("myText.txt")
       source.toSeq.indexOfSlice("myKeyword")
     }
@@ -179,7 +179,7 @@ a `List[String]`-- a list of recent textual posts:
 
     import scala.util.{Success, Failure}
 
-    val f: Future[List[String]] = future {
+    val f: Future[List[String]] = Future {
       session.getRecentPosts
     }
     
@@ -193,7 +193,7 @@ client to handle the result of both failed and successful future
 computations. To handle only successful results, the `onSuccess`
 callback is used (which takes a partial function):
 
-    val f: Future[List[String]] = future {
+    val f: Future[List[String]] = Future {
       session.getRecentPosts
     }
     
@@ -203,7 +203,7 @@ callback is used (which takes a partial function):
 
 To handle failed results, the `onFailure` callback is used:
 
-    val f: Future[List[String]] = future {
+    val f: Future[List[String]] = Future {
       session.getRecentPosts
     }
     
@@ -223,7 +223,7 @@ Since partial functions have the `isDefinedAt` method, the
 particular `Throwable`. In the following example the registered `onFailure`
 callback is never triggered:
 
-    val f = future {
+    val f = Future {
       2 / 0
     }
     
@@ -236,7 +236,7 @@ Coming back to the previous example with searching for the first
 occurrence of a keyword, you might want to print the position
 of the keyword to the screen:
 
-    val firstOccurrence: Future[Int] = future {
+    val firstOccurrence: Future[Int] = Future {
       val source = scala.io.Source.fromFile("myText.txt")
       source.toSeq.indexOfSlice("myKeyword")
     }
@@ -275,7 +275,7 @@ text.
 
     @volatile var totalA = 0
 
-    val text = future {
+    val text = Future {
       "na" * 16 + "BATMAN!!!"
     }
 
@@ -336,12 +336,12 @@ interfacing with a currency trading service. Suppose we want to buy US
 dollars, but only when it's profitable. We first show how this could
 be done using callbacks:
 
-    val rateQuote = future {
+    val rateQuote = Future {
       connection.getCurrentValue(USD)
     }
     
     rateQuote onSuccess { case quote =>
-      val purchase = future {
+      val purchase = Future {
         if (isProfitable(quote)) connection.buy(amount, quote)
         else throw new Exception("not profitable")
       }
@@ -384,7 +384,7 @@ about mapping collections.
 
 Let's rewrite the previous example using the `map` combinator:
 
-    val rateQuote = future {
+    val rateQuote = Future {
       connection.getCurrentValue(USD)
     }
     
@@ -429,8 +429,8 @@ Lets assume that we want to exchange US dollars for Swiss francs
 buying based on both quotes.
 Here is an example of `flatMap` and `withFilter` usage within for-comprehensions:
 
-    val usdQuote = future { connection.getCurrentValue(USD) }
-    val chfQuote = future { connection.getCurrentValue(CHF) }
+    val usdQuote = Future { connection.getCurrentValue(USD) }
+    val chfQuote = Future { connection.getCurrentValue(CHF) }
     
     val purchase = for {
       usd <- usdQuote
@@ -527,12 +527,12 @@ the exception from this future, as in the following example which
 tries to print US dollar value, but prints the Swiss franc value in
 the case it fails to obtain the dollar value:
 
-	val usdQuote = future {
+	val usdQuote = Future {
 	  connection.getCurrentValue(USD)
 	} map {
 	  usd => "Value: " + usd + "$"
 	}
-	val chfQuote = future {
+	val chfQuote = Future {
 	  connection.getCurrentValue(CHF)
 	} map {
 	  chf => "Value: " + chf + "CHF"
@@ -554,7 +554,7 @@ and then renders all the posts to the screen:
 
 	val allposts = mutable.Set[String]()
 	
-	future {
+	Future {
 	  session.getRecentPosts
 	} andThen {
 	  posts => allposts ++= posts
@@ -578,14 +578,14 @@ futures also have projections. If the original future fails, the
 fails with a `NoSuchElementException`. The following is an example
 which prints the exception to the screen:
 
-    val f = future {
+    val f = Future {
       2 / 0
     }
     for (exc <- f.failed) println(exc)
 
 The following example does not print anything to the screen:
 
-    val f = future {
+    val f = Future {
       4 / 2
     }
     for (exc <- f.failed) println(exc)
@@ -605,7 +605,7 @@ the throwable types it matches.
 <!--
 Invoking the `future` construct uses a global execution context to start an asynchronous computation. In the case the client desires to use a custom execution context to start an asynchronous computation:
 
-    val f = customExecutionContext future {
+    val f = customExecutionContext Future {
       4 / 2
     }
 -->
@@ -631,7 +631,7 @@ Here is an example of how to block on the result of a future:
     import scala.concurrent.duration._
     
     def main(args: Array[String]) {
-      val rateQuote = future {
+      val rateQuote = Future {
         connection.getCurrentValue(USD)
       }
       
@@ -724,13 +724,13 @@ that value. This passing of the value is done using a promise.
     val p = promise[T]
     val f = p.future
     
-    val producer = future {
+    val producer = Future {
       val r = produceSomething()
       p success r
       continueDoingSomethingUnrelated()
     }
     
-    val consumer = future {
+    val consumer = Future {
       startDoingSomething()
       f onSuccess {
         case r => doSomethingWithResult()
@@ -756,7 +756,7 @@ The following example shows how to fail a promise.
     val p = promise[T]
     val f = p.future
     
-    val producer = future {
+    val producer = Future {
       val r = someComputation
       if (isInvalid(r))
         p failure (new IllegalStateException)
@@ -801,7 +801,7 @@ The method `completeWith` completes the promise with another
 future. After the future is completed, the promise gets completed with
 the result of that future as well. The following program prints `1`:
 
-    val f = future { 1 }
+    val f = Future { 1 }
     val p = promise[Int]
     
     p completeWith f


### PR DESCRIPTION
Hi I updated the example in order to adopt the syntax:

    Future{ ... }

in the examples, as suggested by the annotation:

    @deprecated("Use `Future { ... }` instead.", "2.11.0")

on the constructor itself