### PR TITLE
Add SLIPs (Scala Library Improvement Process) to SIP pages

### DIFF
--- a/_includes/allsids.txt
+++ b/_includes/allsids.txt
@@ -1,7 +1,7 @@
-<h3>Pending SIPs</h3>
+<h3>Pending SLIPs</h3>
 <ul class="post-list">
   {% for post in site.categories.pending %}
-    {% if post.layout == 'sip' %}
+    {% if post.layout == 'slip' %}
       <li><a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a> <span class="date">( {{ post.date | date: "%b %Y" }} )</span>
       {% if post.vote-status %}
         {% if post.vote-status == 'accepted' %}
@@ -19,10 +19,10 @@
   {% endfor %}
 </ul>
 
-<h3>Pending SLIPs</h3>
+<h3>Pending SIPs</h3>
 <ul class="post-list">
   {% for post in site.categories.pending %}
-    {% if post.layout == 'slip' %}
+    {% if post.layout == 'sip' %}
       <li><a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a> <span class="date">( {{ post.date | date: "%b %Y" }} )</span>
       {% if post.vote-status %}
         {% if post.vote-status == 'accepted' %}

--- a/_includes/allsids.txt
+++ b/_includes/allsids.txt
@@ -1,19 +1,41 @@
 <h3>Pending SIPs</h3>
 <ul class="post-list">
   {% for post in site.categories.pending %}
-    <li><a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a> <span class="date">( {{ post.date | date: "%b %Y" }} )</span>
-    {% if post.vote-status %}
-      {% if post.vote-status == 'accepted' %}
-      <span class="label success">Accepted</span>
-      {% elsif post.vote-status == 'deferred' %}
-        <span class="label warning">Deferred</span>
-      {% elsif post.vote-status == 'postponed' %}
-        <span class="label warning">Postponed</span>
-      {% elsif post.vote-status == 'not accepted' %}
-        <span class="label danger">Not Accepted</span>
+    {% if post.layout == 'sip' %}
+      <li><a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a> <span class="date">( {{ post.date | date: "%b %Y" }} )</span>
+      {% if post.vote-status %}
+        {% if post.vote-status == 'accepted' %}
+        <span class="label success">Accepted</span>
+        {% elsif post.vote-status == 'deferred' %}
+          <span class="label warning">Deferred</span>
+        {% elsif post.vote-status == 'postponed' %}
+          <span class="label warning">Postponed</span>
+        {% elsif post.vote-status == 'not accepted' %}
+          <span class="label danger">Not Accepted</span>
+        {% endif %}
       {% endif %}
+      </li>
     {% endif %}
-    </li>
-  {% endfor %}      
+  {% endfor %}
 </ul>
 
+<h3>Pending SLIPs</h3>
+<ul class="post-list">
+  {% for post in site.categories.pending %}
+    {% if post.layout == 'slip' %}
+      <li><a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a> <span class="date">( {{ post.date | date: "%b %Y" }} )</span>
+      {% if post.vote-status %}
+        {% if post.vote-status == 'accepted' %}
+        <span class="label success">Accepted</span>
+        {% elsif post.vote-status == 'deferred' %}
+          <span class="label warning">Deferred</span>
+        {% elsif post.vote-status == 'postponed' %}
+          <span class="label warning">Postponed</span>
+        {% elsif post.vote-status == 'not accepted' %}
+          <span class="label danger">Not Accepted</span>
+        {% endif %}
+      {% endif %}
+      </li>
+    {% endif %}
+  {% endfor %}
+</ul>

--- a/_includes/sips-topbar.txt
+++ b/_includes/sips-topbar.txt
@@ -5,9 +5,10 @@
         <div class="container">
           <a class="brand" href="{{ site.baseurl }}/sips/index.html"><img src="{{ site.baseurl }}/resources/images/scala-logo.png"> Improvement Process</a>
           <ul class="nav">
-           <li><a href="{{ site.baseurl }}/sips/sip-submission.html">Submitting a new SIP</a></li>
-           <li><a href="{{ site.baseurl }}/sips/sip-list.html">SIP List</a></li>
-           <li><a href="{{ site.baseurl }}/sips/sip-tutorial.html">Tutorial: Writing a SIP</a></li>
+           <li><a href="{{ site.baseurl }}/sips/sip-submission.html">Submitting a SIP</a></li>
+           <li><a href="{{ site.baseurl }}/sips/slip-submission.html">Submitting a SLIP</a></li>
+           <li><a href="{{ site.baseurl }}/sips/sip-list.html">SIP/SLIP List</a></li>
+           <li><a href="{{ site.baseurl }}/sips/sip-tutorial.html">Tutorial: Writing a SIP/SLIP</a></li>
            <li><a href="https://groups.google.com/forum/#!forum/scala-sips">Mailing List</a></li>
           </ul>
         </div>

--- a/_includes/topbar.txt
+++ b/_includes/topbar.txt
@@ -35,7 +35,7 @@
                 </li>
 
                 <li><a href="{{ site.baseurl }}/contribute.html">Contribute</a></li>
-                <li><a href="{{ site.baseurl }}/sips">SIPs</a></li>
+                <li><a href="{{ site.baseurl }}/sips">SIPs/SLIPs</a></li>
                 <li><a href="http://wiki.scala-lang.org">Wiki</a></li>
           </ul>
           <form method="get" id="searchform" action="{{ site.baseurl }}/search.html">

--- a/_layouts/slip.html
+++ b/_layouts/slip.html
@@ -1,0 +1,23 @@
+---
+layout: default
+---
+{% include header.txt %}
+{% include sips-topbar.txt %}
+
+<div class="container">
+  <div class="row">
+
+    <div class="span12">
+      {% if page.title %}<h1>{{ page.title }}</h1>{% else %}<h1>{{ site.title }}</h1>{% endif %}
+      {{ content }}
+      {% if page.disqus == true %}{% include disqus.txt %}{% endif %}
+    </div>
+
+    <div class="span4">
+      {% include toc.txt %}
+    </div>
+
+  </div>
+</div>
+
+{% include footer.txt %}

--- a/sips/README.md
+++ b/sips/README.md
@@ -1,9 +1,9 @@
 # Scala Improvement Process Documents
 
-This directory contains the source of the SIP website, including all pending/finished/rejected SIPs.
+This directory contains the source of the SIP website, including all pending/finished/rejected SIPs and SLIPs.
 
 
-## Migrating a SIP to other states
+## Migrating a SIP or SLIP to other states
 
 To reject a SIP simply:
 
@@ -12,3 +12,6 @@ To reject a SIP simply:
 To mark a SIP completed simply:
 
     git mv pending/_posts/{sip-file}  completed/_posts/{sip-file}
+
+The process is the same for SLIPs, which are identical except for their layout
+being slip instead of sip in the document header.

--- a/sips/index.md
+++ b/sips/index.md
@@ -6,8 +6,36 @@ title: Scala Improvement Process
 
 # Welcome #
 
-This is the landing page for the Scala Improvement Process.
+This is the landing page for the Scala Improvement Process (SIP) and the
+Scala Library Improvement Process (SLIP).
 
-This process has been changed since the old SID (Scala Improvement Document) days, however the old completed SID documents are available in the [completed section of the SIP list](sip-list.html).
+The SIP process replaced the older SID (Scala Improvement Document) process,
+however the old completed SID documents are still available to review in the
+[completed section of the SIP list](sip-list.html).
 
+## SIPs
 
+SIPs are for changes to the Scala language and/or compiler and are subject to a
+[rigorous review process](./sip-submission.html) and are usually accompanied by
+changes to the [Scala language specification](http://www.scala-lang.org/docu/files/ScalaReference.pdf),
+lots of review and discussion on
+the [scala-internals](https://groups.google.com/forum/#!forum/scala-internals) mailing list
+and voting/approval milestones. Please read
+[Submitting a SIP](./sip-submission.html) and our [SIP tutorial](./sip-tutorial.html) for
+more information.
+
+## SLIPs
+
+For changes and additions to the Scala core libraries (i.e. those distributed
+with the main scala-lang download), a still rigorous (yet less demanding) process
+called the Scala Library Improvement Process (SLIP) exists.
+
+SLIPs are intended for any library addition or modification that does not require
+associated changes to the Scala language or compiler.
+
+[Submitting a SLIP](./slip-submission.html) covers the process, and the
+[SIP tutorial](./sip-tutorial.html) has information on how to write and format
+your SLIP document.
+
+Logistically, SLIPs share a lot of infrastructure with SIPs, including sharing the
+[SIP mailing list](https://groups.google.com/forum/#!forum/scala-sips).

--- a/sips/index.md
+++ b/sips/index.md
@@ -13,17 +13,6 @@ The SIP process replaced the older SID (Scala Improvement Document) process,
 however the old completed SID documents are still available to review in the
 [completed section of the SIP list](sip-list.html).
 
-## SIPs
-
-SIPs are for changes to the Scala language and/or compiler and are subject to a
-[rigorous review process](./sip-submission.html) and are usually accompanied by
-changes to the [Scala language specification](http://www.scala-lang.org/docu/files/ScalaReference.pdf),
-lots of review and discussion on
-the [scala-internals](https://groups.google.com/forum/#!forum/scala-internals) mailing list
-and voting/approval milestones. Please read
-[Submitting a SIP](./sip-submission.html) and our [SIP tutorial](./sip-tutorial.html) for
-more information.
-
 ## SLIPs
 
 For changes and additions to the Scala core libraries (i.e. those distributed
@@ -39,3 +28,15 @@ your SLIP document.
 
 Logistically, SLIPs share a lot of infrastructure with SIPs, including sharing the
 [SIP mailing list](https://groups.google.com/forum/#!forum/scala-sips).
+
+## SIPs
+
+SIPs are for changes to the Scala language and/or compiler and are subject to a
+[rigorous review process](./sip-submission.html) and are usually accompanied by
+changes to the [Scala language specification](http://www.scala-lang.org/docu/files/ScalaReference.pdf),
+lots of review and discussion on
+the [scala-internals](https://groups.google.com/forum/#!forum/scala-internals) mailing list
+and voting/approval milestones. Please read
+[Submitting a SIP](./sip-submission.html) and our [SIP tutorial](./sip-tutorial.html) for
+more information.
+

--- a/sips/sip-list.md
+++ b/sips/sip-list.md
@@ -1,18 +1,40 @@
 ---
 layout: sip-landing
-title: List of SIPs
+title: List of SIPs and SLIPs
 ---
 
 ### Completed SIPs ###
 <ul class="post-list">
   {% for post in site.categories.completed %}
-    <li><a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a> <span class="date">( {{ post.date | date: "%b %Y" }} )</span></li>
-  {% endfor %}      
+    {% if post.layout == 'sip' %}
+      <li><a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a> <span class="date">( {{ post.date | date: "%b %Y" }} )</span></li>
+    {% endif %}
+  {% endfor %}
 </ul>
 
 ### Rejected SIPs ###
 <ul class="post-list">
   {% for post in site.categories.rejected %}
-    <li><a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a> <span class="date">( {{ post.date | date: "%b %Y" }} )</span></li>
-  {% endfor %}      
+    {% if post.layout == 'sip' %}
+      <li><a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a> <span class="date">( {{ post.date | date: "%b %Y" }} )</span></li>
+    {% endif %}
+  {% endfor %}
+</ul>
+
+### Completed SLIPs ###
+<ul class="post-list">
+  {% for post in site.categories.completed %}
+    {% if post.layout == 'slip' %}
+      <li><a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a> <span class="date">( {{ post.date | date: "%b %Y" }} )</span></li>
+    {% endif %}
+  {% endfor %}
+</ul>
+
+### Rejected SLIPs ###
+<ul class="post-list">
+  {% for post in site.categories.rejected %}
+    {% if post.layout == 'slip' %}
+      <li><a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a> <span class="date">( {{ post.date | date: "%b %Y" }} )</span></li>
+    {% endif %}
+  {% endfor %}
 </ul>

--- a/sips/sip-list.md
+++ b/sips/sip-list.md
@@ -3,6 +3,24 @@ layout: sip-landing
 title: List of SIPs and SLIPs
 ---
 
+### Completed SLIPs ###
+<ul class="post-list">
+  {% for post in site.categories.completed %}
+    {% if post.layout == 'slip' %}
+      <li><a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a> <span class="date">( {{ post.date | date: "%b %Y" }} )</span></li>
+    {% endif %}
+  {% endfor %}
+</ul>
+
+### Rejected SLIPs ###
+<ul class="post-list">
+  {% for post in site.categories.rejected %}
+    {% if post.layout == 'slip' %}
+      <li><a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a> <span class="date">( {{ post.date | date: "%b %Y" }} )</span></li>
+    {% endif %}
+  {% endfor %}
+</ul>
+
 ### Completed SIPs ###
 <ul class="post-list">
   {% for post in site.categories.completed %}
@@ -21,20 +39,3 @@ title: List of SIPs and SLIPs
   {% endfor %}
 </ul>
 
-### Completed SLIPs ###
-<ul class="post-list">
-  {% for post in site.categories.completed %}
-    {% if post.layout == 'slip' %}
-      <li><a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a> <span class="date">( {{ post.date | date: "%b %Y" }} )</span></li>
-    {% endif %}
-  {% endfor %}
-</ul>
-
-### Rejected SLIPs ###
-<ul class="post-list">
-  {% for post in site.categories.rejected %}
-    {% if post.layout == 'slip' %}
-      <li><a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a> <span class="date">( {{ post.date | date: "%b %Y" }} )</span></li>
-    {% endif %}
-  {% endfor %}
-</ul>

--- a/sips/sip-submission.md
+++ b/sips/sip-submission.md
@@ -26,30 +26,32 @@ The SIP committee will have a look at your proposal. If it is looks promising, i
 
 ## What will happen afterwards ##
 
-The SIP will get a unique number. It should be discussed on the scala-sips mailing list. In these mails, every mail that is specific to a SIP ### should be prefixed with \[SIP-###\]. Typically, a SIP under discussion will have a member of the committee as sheperd, to help move it forward.
+The SIP will get a unique number. It should be discussed on the [scala-sips mailing list](https://groups.google.com/forum/#!forum/scala-sips).
+In these mails, every mail that is specific to a SIP ### should be prefixed with \[SIP-###\].
+Typically, a SIP under discussion will have a member of the committee as shepherd, to help move it forward.
 
-Before a SIP can be accepted, it also needs a full implementation that can be evaluated in practice. That implementation can be done before the SIP is submitted, or else concurrently with the discussion period.
+Before a SIP can be accepted, it also needs a full implementation that can be evaluated in practice.
+That implementation can be done before the SIP is submitted, or else concurrently with the discussion period.
 
-## What is the provisonal voting status? ##
+## What is the provisional voting status? ##
 
-When a release is drawing near, the SIP committee will hold on provisonal vote on pending SIPs.  This vote places sips in one of the current status:
+When a release is drawing near, the SIP committee will hold on provisional vote on pending SIPs.  This vote places sips in one of the current status:
 
 * `Accepted` - The SIP will be included in the next release, pending an acceptable implementation.
 * `Deferred - Next Meeting` - The committee has concerned that need to be addressed in the SIP before inclusion in the Release. If the concerns are handled before the next release, the SIP will be re-evaluated.
-* `Delay - Next Release` - The SIP comittee has larger concerns with the state of the SIP and would prefer to wait until the next Scala release to consider inclusion.
-* `Not Accepted` - The SIP comittee feels the SIP is not needed for the Scala language and turns down the proposal, with an explanation of why.
+* `Delay - Next Release` - The SIP committee has larger concerns with the state of the SIP and would prefer to wait until the next Scala release to consider inclusion.
+* `Not Accepted` - The SIP committee feels the SIP is not needed for the Scala language and turns down the proposal, with an explanation of why.
 
 ## What happens for a Scala major release? ##
 
 Before a Scala release, the committee will make a final decision for each SIP whether it should be accepted, rejected, or delayed for the next release. Accepted SIPs will be rolled into an upcoming Scala release and placed in the accepted folder.  Rejected SIPs will be left in the SIP repository under the "rejected sips" section.  Delayed SIPs will remain pending.
- 
+
 
 ## Who is on the SIP committee ##
 
 Right Now:
 
 * Martin Odersky
-* Paul Philips
 * Josh Suereth
 * Adriaan Moors
 

--- a/sips/sip-tutorial.md
+++ b/sips/sip-tutorial.md
@@ -1,6 +1,6 @@
 ---
 layout: sip-landing
-title: Writing a new SIP
+title: Writing a new SIP or SLIP
 ---
 
 This tutorial details of how to write a new SIP and adding it to the website.   Currently two mechanisms of providing a new SIP are recommended:
@@ -9,20 +9,26 @@ This tutorial details of how to write a new SIP and adding it to the website.   
 * Using Google Docs.
 
 
-## Writing a SIP in Markdown ##
+## Writing a SIP/SLIP in Markdown ##
 
-First, create a new SIP file in the `pending/_posts` directory.  Make sure the new file follows the format:  `YYYY-MM-dd-{title}.md`.  Where:
-* `YYYY` is the current year when the proposal orginated.
-* `MM` is the current month (`01` = january, `12` = decemeber) when the proposal originated.
-* `dd` is the day of the month when the proposal orginated.
-* `{title}` is the title for the SIP.
+First, create a new SIP/SLIP file in the `pending/_posts` directory.  Make sure the new file follows the format:  `YYYY-MM-dd-{title}.md`.  Where:
+* `YYYY` is the current year when the proposal originated.
+* `MM` is the current month (`01` = January, `12` = December) when the proposal originated.
+* `dd` is the day of the month when the proposal originated.
+* `{title}` is the title for the SIP or SLIP.
 
 
 ### Markdown formatting ###
 
-Use the [Markdown Syntax](http://daringfireball.net/projects/markdown/syntax) to write your SIP.
+Use the [Markdown Syntax](http://daringfireball.net/projects/markdown/syntax) to write your SIP/SLIP.
 
-See the [source](https://github.com/scala/scala.github.com/blob/gh-pages/sips/sip-tutorial.md) for this document (`sip-tutorial.md`) for how to do sytnax highlighting.
+If you would like a starting point, clone the [SLIP Template](./slip-template.html) in
+`sips/pending/slip-template.md` and use that. For now (as we don't have a specific
+SIP template) you can also use this for SIPs, just rename it to a SIP in the title
+and change the layout: field at the top to sip (instead of slip) to make sure it
+shows up in the right lists.
+
+See the [source](https://github.com/scala/scala.github.com/blob/gh-pages/sips/sip-tutorial.md) for this document (`sip-tutorial.md`) for how to do syntax highlighting.
 
 {% highlight scala %}
 class Foo

--- a/sips/slip-submission.md
+++ b/sips/slip-submission.md
@@ -5,31 +5,29 @@ title: SLIP Submission Process
 
 ## How do I get started? ##
 
+Before proposing a new SLIP or new library functionality, it's a good idea
+to get a feel for the core libraries first, and there's no better way than
+by helping fix some of the 
+[core library issues in community tickets](http://scala-lang.org/contribute/#community_tickets).
+
+## Pre-requisites
+
 SLIP (Scala Library Improvement Process) is a way to suggest, define, implement and submit
 changes, additions and enhancements to the Scala core libraries. Because it benefits us
 as a community to avoid adding libraries and APIs without careful thought, please read the
 following before deciding to create you SLIP:
 
-* Suggested functionality should not duplicate existing capabilities in the core libraries.
-  If you want to change existing functionality, suggest that, but be ready for questions of
-  backwards compatibility, migration strategies and other concerns. However if you want to
-  add APIs to the core libraries, they should be demonstrably different from those already
-  there, or offer extra functionality not available in the current APIs, or ideally both.
+* The suggested functionality should not conflict with nor directly duplicate existing core library functionality.  If you want to change existing functionality, suggest that, but be ready for questions of
+  backwards compatibility, migration strategies and other concerns. Note that some concepts will be repeated but your functionality should be demonstrably different from that available in either implementation or intent, or both.
+* You may be asked to establish your credentials for submitting code to the core Scala libraries. Implementing popular and established third party libraries for Scala, or contributing bug-fixes to the existing core libraries are ways you can establish your credentials.
 * Any additions or modifications must maintain the existing "feel" of the current core Scala libraries.
   Design questions will likely be asked through during the SLIP reviews to ensure that
-  this aspect has been considered.
+  this aspect has been considered. At the very least an executable/usable proof-of-concept should be provided for reviewers to try out. Ideally the SLIP will be drawn from an existing established library which can be noted in the SLIP submission.
 * Additions or modifications must also be tried and tested. Tested means a strong, complete
   testing suite, tried usually means that the functionality will be drawn from an existing,
   established library that has demonstrated it's utility, reliability and stability already.
-* Typically your contributions will go into an auxiliary library jar that is distributed
-  with the Scala language download, as with the parser combinator and reflection modules
-  (there is a push towards greater modularity within the libraries now). Give some thought
-  to the name of the library you are proposing. If you believe it should be included
-  in the core Scala library jar, you will likely be asked to explain and defend
-  that position.
-* The best starting point is an existing, working library from which you can draw your
-  implementation. Likely you will be cherry picking functionality from the library
-  rather than submitting the whole thing.
+* You should have more than one responsible developer for the SLIP (having one name on the SLIP is not enough, find a second).
+* You may be asked to find a champion or sponsor for your SLIP from the current SLIP committee members.
 
 ## How do I submit? ##
 
@@ -47,7 +45,7 @@ The process to submit is simple:
 * Commit your changes to your forked repository
 * Create a new [pull request](https://github.com/scala/scala.github.com/pull/new/gh-pages).  This will notify the Scala SIP team.
 
-## What will happen next ##
+## Approval/Acceptance ##
 
 The SLIP committee will have a look at your proposal. If it is looks promising, it will be made into a SLIP. At that point, you'll have to sign a CLA (contributor license agreement) which says that you are OK with the text of the proposal and the implementation being used in the Scala project.
 
@@ -55,7 +53,7 @@ It will also be opened to a brief public review, no more than 2 weeks to gather 
 The result of this public review period may be some requested changes to the design or implementation
 of the library, its tests, or its scope.
 
-## What will happen afterwards ##
+## Progression of the SLIP to Completion ##
 
 The SLIP will get a unique number. It should be discussed on the [scala-sips mailing list](https://groups.google.com/forum/#!forum/scala-sips).
 In these mails, every mail that is specific to a SLIP ### should be prefixed with \[SLIP-###\].

--- a/sips/slip-submission.md
+++ b/sips/slip-submission.md
@@ -1,0 +1,87 @@
+---
+layout: sip-landing
+title: SLIP Submission Process
+---
+
+## How do I get started? ##
+
+SLIP (Scala Library Improvement Process) is a way to suggest, define, implement and submit
+changes, additions and enhancements to the Scala core libraries. Because it benefits us
+as a community to avoid adding libraries and APIs without careful thought, please read the
+following before deciding to create you SLIP:
+
+* Suggested functionality should not duplicate existing capabilities in the core libraries.
+  If you want to change existing functionality, suggest that, but be ready for questions of
+  backwards compatibility, migration strategies and other concerns. However if you want to
+  add APIs to the core libraries, they should be demonstrably different from those already
+  there, or offer extra functionality not available in the current APIs, or ideally both.
+* Any additions or modifications must maintain the existing "feel" of the current core Scala libraries.
+  Design questions will likely be asked through during the SLIP reviews to ensure that
+  this aspect has been considered.
+* Additions or modifications must also be tried and tested. Tested means a strong, complete
+  testing suite, tried usually means that the functionality will be drawn from an existing,
+  established library that has demonstrated it's utility, reliability and stability already.
+* Typically your contributions will go into an auxiliary library jar that is distributed
+  with the Scala language download, as with the parser combinator and reflection modules
+  (there is a push towards greater modularity within the libraries now). Give some thought
+  to the name of the library you are proposing. If you believe it should be included
+  in the core Scala library jar, you will likely be asked to explain and defend
+  that position.
+* The best starting point is an existing, working library from which you can draw your
+  implementation. Likely you will be cherry picking functionality from the library
+  rather than submitting the whole thing.
+
+## How do I submit? ##
+
+The process to submit is simple:
+
+* Fork the Scala documentation repository, [http://github.com/scala/scala.github.com](http://github.com/scala/scala.github.com).
+* Create a new SLIP file in the `sips/pending/_posts/` using the [SLIP Template](./slip-template.html) in
+  `sips/pending/slip-template.md` as
+  a starting point. Check the [Writing a SIP Tutorial](sip-tutorial.html) for more help.
+  * Make sure the new file follows the format:  `YYYY-MM-dd-{title}.md`.  Use the proposal date for `YYYY-MM-dd`.
+  * Use the [Markdown Syntax](http://daringfireball.net/projects/markdown/syntax) to write your SLIP.
+  * Follow the instructions in the [README](https://github.com/scala/scala.github.com/blob/gh-pages/README.md)
+    to build your SLIP locally so you can ensure that it looks correct on the website.
+  * Ensure the SLIP is listed under Pending SLIPs on the [SIPs index page](./index.html)
+* Commit your changes to your forked repository
+* Create a new [pull request](https://github.com/scala/scala.github.com/pull/new/gh-pages).  This will notify the Scala SIP team.
+
+## What will happen next ##
+
+The SLIP committee will have a look at your proposal. If it is looks promising, it will be made into a SLIP. At that point, you'll have to sign a CLA (contributor license agreement) which says that you are OK with the text of the proposal and the implementation being used in the Scala project.
+
+It will also be opened to a brief public review, no more than 2 weeks to gather comments and concerns from anyone interested.
+The result of this public review period may be some requested changes to the design or implementation
+of the library, its tests, or its scope.
+
+## What will happen afterwards ##
+
+The SLIP will get a unique number. It should be discussed on the [scala-sips mailing list](https://groups.google.com/forum/#!forum/scala-sips).
+In these mails, every mail that is specific to a SLIP ### should be prefixed with \[SLIP-###\].
+
+Before a SIP can be accepted, it also needs a full implementation that can be evaluated in practice. That implementation can be done before the SLIP is submitted, or else concurrently with the discussion period.
+
+## What is the provisional voting status? ##
+
+When a release is drawing near, the SLIP committee will hold on provisional vote on pending SLIPs.  This vote places slips in one of the current status:
+
+* `Accepted` - The SLIP will be included in the next release, pending an acceptable implementation.
+* `Deferred - Next Meeting` - The committee has concerned that need to be addressed in the SLIP before inclusion in the Release. If the concerns are handled before the next release, the SLIP will be re-evaluated.
+* `Delay - Next Release` - The SLIP committee has larger concerns with the state of the SLIP and would prefer to wait until the next Scala release to consider inclusion.
+* `Not Accepted` - The SLIP committee feels the SLIP is not needed for the Scala language and turns down the proposal, with an explanation of why.
+
+## What happens for a Scala major release? ##
+
+Before a Scala release, the committee will make a final decision for each SLIP whether it should be accepted, rejected, or delayed for the next release. Accepted SLIPs will be rolled into an upcoming Scala release and placed in the accepted folder.  Rejected SLIPs will be left in the SIP repository under the "rejected slips" section.  Delayed SLIPs will remain pending.
+
+
+## Who is on the SLIP committee ##
+
+Right Now:
+
+* Martin Odersky
+* Josh Suereth
+* Adriaan Moors
+
+We will ask new members to join from time to time.   The committee decides collectively, but Martin reserves the final say if there is a disagreement.

--- a/sips/slip-template.md
+++ b/sips/slip-template.md
@@ -1,0 +1,103 @@
+---
+layout: slip
+disqus: true
+title: SLIP-NN - SLIP Title
+---
+
+**By: Author 1 and Author 2 and Author 3**
+
+This document is provided as a template to get you started. Feel free to add, augment,
+remove, restructure and otherwise adapt the structure for what you need after cloning it.
+The cloned document should be placed in sips/pending/_posts according to the naming
+conventions described in the [SIP tutorial](./sip-tutorial.html). SIPs and SLIPs share
+organization and infrastructure on docs.scala-lang.org to reduce duplication.
+
+## History
+
+| Date          | Version       |
+|---------------|---------------|
+| Feb 19th 2015 | Initial Draft |
+| Feb 20th 2015 | Alteration Details |
+
+## Introduction/Motivation/Abstract
+
+(feel free to rename this section to Introduction, Motivation, Abstract, whatever best suits
+  your library proposal.)
+
+A high level overview of the library with:
+
+* Description of the scope/features of the library.
+* An explanation of the reason the library is needed, what's missing in the core libs
+  that is supplied.
+* Simple code examples if they help clarify, note that there will be ample opportunity
+  for more detailed code examples later in the SLIP
+
+Think of the introduction as serving to describe the library addition in a way
+that lets a reader decide if this is what they are looking for, whether they think
+this is the right approach to supply the extra functionality, and whether they might
+want to get involved.
+
+## Motivating Examples
+
+### Examples
+
+Code heavy description of how the library functionality can be used.
+
+{% highlight scala %}
+// here is some example scala code, highlighted nicely
+import scala.concurrent._
+
+class Foo extends Bar {
+  val x = 10
+  def yo(name: String): String = s"hello $name"
+}
+{% endhighlight %}
+
+### Comparison Examples
+
+Code demonstrating why the library is needed, how equivalent functionality
+might be provided without it.
+
+### Counter-Examples
+
+What the library is not intended to be used for. Examples of what to avoid and
+why.
+
+## Design
+
+Discuss design decisions (including, as examples):
+
+* Reason about correctness of the implementation.
+* "Feel and fit" with existing core libraries.
+* Performance and threading considerations.
+* Naming of classes, traits, methods.
+* Footprint of API.
+* Potential conflicts with existing libraries, e.g. name clashes, IDE auto-import friction, etc.
+
+## Implementation
+
+Include consideration of the following:
+
+* Is this library intended to be bundled with the current core libs, or (recommended) live in
+a separate module distributed with the core distribution of Scala
+(e.g. parser combinators, reflection, etc.)
+* **Existing implementation(s)** (e.g. donor library, github project, etc.). Note that
+having an existing implementation library from which this will be drawn, and that people
+can download and try now, is highly recommended.
+* Time frame, target Scala version for inclusion.
+* Roll-out plan (start with external module, include in std distribution, move to core).
+* Other volunteers/contributors (with areas of expertise, github contact info, etc.)
+
+## References
+
+1. [Existing (Donor) Project][1]
+2. [API Documentation][2]
+3. [Academic/Research papers/supporting material][3]
+4. [Alternative Libraries/Implementations][4]
+5. [Discussion forum/post/gitter/IRC][5]
+
+[1]: http://github.com "Github"
+[2]: http://www.scala-lang.org/api/ "Scaladoc"
+[3]: http://en.wikipedia.org/wiki/Academic_publishing "Academic/Research"
+[4]: https://github.com/dogescript/dogescript "Alternatives"
+[5]: https://gitter.im "Gitter"


### PR DESCRIPTION
* Include new SLIP template
* Segregate SLIPS from SIPs
* Update all referencing materials
* Various typo and spelling fixes

As with the tools pages changes, this is intended to be a straw man for discussion rather than direct inclusion. Will likely dump this PR and create a new one with squashed changes once we have gathered comments.

Review by @heathermiller and @adriaanm 