### PR TITLE
Fixes to architecture-of-scala-collections

### DIFF
--- a/overviews/core/_posts/2010-12-15-architecture-of-scala-collections.md
+++ b/overviews/core/_posts/2010-12-15-architecture-of-scala-collections.md
@@ -35,11 +35,11 @@ support.
 
 ## Builders ##
 
-An outline of the `Builder` class:
+An outline of the `Builder` trait:
 
     package scala.collection.mutable
     
-    class Builder[-Elem, +To] {
+    trait Builder[-Elem, +To] {
       def +=(elem: Elem): this.type
       def result(): To
       def clear(): Unit
@@ -50,11 +50,12 @@ Almost all collection operations are implemented in terms of
 *traversals* and *builders*. Traversals are handled by `Traversable`'s
 `foreach` method, and building new collections is handled by instances
 of class `Builder`. The listing above presents a slightly abbreviated
-outline of this class.
+outline of this trait.
 
 You can add an element `x` to a builder `b` with `b += x`. There's also
-syntax to add more than one element at once, for instance `b += (x, y)`,
-and `b ++= xs` work as for buffers (in fact, buffers are an enriched
+syntax to add more than one element at once, for instance `b += (x, y)`.
+Adding another collection with `b ++= xs` works as for buffers (in fact,
+buffers are an enriched
 version of builders). The `result()` method returns a collection from a
 builder. The state of the builder is undefined after taking its
 result, but it can be reset into a new empty state using
@@ -85,13 +86,13 @@ result is that `bldr` is a builder for arrays.
 
 ## Factoring out common operations ##
 
-### Outline of class TraversableLike ###
+### Outline of trait TraversableLike ###
 
     package scala.collection
   
-    class TraversableLike[+Elem, +Repr] {
+    trait TraversableLike[+Elem, +Repr] {
       def newBuilder: Builder[Elem, Repr] // deferred
-      def foreach[U](f: Elem => U)        // deferred
+      def foreach[U](f: Elem => U): Unit  // deferred
               ...
       def filter(p: Elem => Boolean): Repr = {
         val b = newBuilder
@@ -116,13 +117,13 @@ The Scala collection library avoids code duplication and achieves the
 over collections in so-called *implementation traits*. These traits are
 named with a `Like` suffix; for instance, `IndexedSeqLike` is the
 implementation trait for `IndexedSeq`, and similarly, `TraversableLike` is
-the implementation trait for `Traversable`. Collection classes such as
+the implementation trait for `Traversable`. Collection traits such as
 `Traversable` or `IndexedSeq` inherit all their concrete method
 implementations from these traits. Implementation traits have two type
 parameters instead of one for normal collections. They parameterize
 not only over the collection's element type, but also over the
 collection's *representation type*, i.e., the type of the underlying
-collection, such as `Seq[I]` or `List[T]`. For instance, here is the
+collection, such as `Seq[T]` or `List[T]`. For instance, here is the
 header of trait `TraversableLike`:
 
     trait TraversableLike[+Elem, +Repr] { ... }
@@ -137,14 +138,15 @@ collection implementation trait.
 
 Taking `filter` as an example, this operation is defined once for all
 collection classes in the trait `TraversableLike`. An outline of the
-relevant code is shown in the above [outline of class
-`TraversableLike`](#outline_of_class_traversablelike). The trait declares two abstract methods, `newBuilder`
+relevant code is shown in the above [outline of trait
+`TraversableLike`](#outline-of-trait-traversablelike). The trait declares
+two abstract methods, `newBuilder`
 and `foreach`, which are implemented in concrete collection classes. The
 `filter` operation is implemented in the same way for all collections
 using these methods. It first constructs a new builder for the
 representation type `Repr`, using `newBuilder`. It then traverses all
 elements of the current collection, using `foreach`. If an element `x`
-satisfies the given predicate `p` (i.e., `p(x)` is `true`), it is added with
+satisfies the given predicate `p` (i.e., `p(x)` is `true`), it is added to
 the builder. Finally, the elements collected in the builder are
 returned as an instance of the `Repr` collection type by calling the
 builder's `result` method.
@@ -153,9 +155,10 @@ A bit more complicated is the `map` operation on collections. For
 instance, if `f` is a function from `String` to `Int`, and `xs` is a
 `List[String]`, then `xs map f` should give a `List[Int]`. Likewise,
 if `ys` is an `Array[String]`, then `ys map f` should give an
-`Array[Int]`. The problem is how to achieve that without duplicating
+`Array[Int]`. The question is how do we achieve that without duplicating
 the definition of the `map` method in lists and arrays. The
-`newBuilder`/`foreach` framework shown in [class `TraversableLike`](#outline_of_class_traversablelike) is
+`newBuilder`/`foreach` framework shown in
+[trait `TraversableLike`](#outline-of-trait-traversablelike) is
 not sufficient for this because it only allows creation of new
 instances of the same collection *type* whereas `map` needs an
 instance of the same collection *type constructor*, but possibly with
@@ -191,7 +194,7 @@ function argument is something else, the result of `map` is just a
 Scala.
 
 The problem with `BitSet` is not an isolated case. Here are two more
-interactions with the interpreter that both map a function over a map:
+interactions with the interpreter that both map a function over a `Map`:
 
     scala> Map("a" -> 1, "b" -> 2) map { case (x, y) => (y, x) }
     res3: scala.collection.immutable.Map[Int,java.lang.String] 
@@ -206,12 +209,12 @@ of mapping this function is again a map, but now going in the other
 direction. In fact, the first expression yields the inverse of the
 original map, provided it is invertible. The second function, however,
 maps the key/value pair to an integer, namely its value component. In
-that case, we cannot form a `Map` from the results, but we still can
+that case, we cannot form a `Map` from the results, but we can still
 form an `Iterable`, a supertrait of `Map`.
 
 You might ask, why not restrict `map` so that it can always return the
 same kind of collection? For instance, on bit sets `map` could accept
-only `Int`-to-`Int` functions and on maps it could only accept
+only `Int`-to-`Int` functions and on `Map`s it could only accept
 pair-to-pair functions. Not only are such restrictions undesirable
 from an object-oriented modelling point of view, they are illegal
 because they would violate the Liskov substitution principle: A `Map` *is*
@@ -225,18 +228,18 @@ by implicit parameters.
 
 Implementation of `map` in `TraversableLike`:
 
-    def map[B, That](p: Elem => B)
-        (implicit bf: CanBuildFrom[B, That, This]): That = {
+    def map[B, That](f: Elem => B)
+        (implicit bf: CanBuildFrom[Repr, B, That]): That = {
       val b = bf(this)
-      for (x <- this) b += f(x)
+      this.foreach(x => b += f(x))
       b.result
     }
 
 The listing above shows trait `TraversableLike`'s implementation of
-`map`. It's quite similar to the implementation of `filter` shown in [class
-`TraversableLike`](#outline_of_class_traversablelike).
+`map`. It's quite similar to the implementation of `filter` shown in [trait
+`TraversableLike`](#outline-of-trait-traversablelike).
 The principal difference is that where `filter` used
-the `newBuilder` method, which is abstract in class `TraversableLike`, `map`
+the `newBuilder` method, which is abstract in `TraversableLike`, `map`
 uses a *builder factory* that's passed as an additional implicit
 parameter of type `CanBuildFrom`.
 
@@ -250,16 +253,17 @@ The `CanBuildFrom` trait:
     }
 
 The listing above shows the definition of the trait `CanBuildFrom`,
-which represents builder factories. It has three type parameters: `Elem`
-indicates the element type of the collection to be built, `To` indicates
-the type of collection to build, and `From` indicates the type for which
-this builder factory applies. By defining the right implicit
+which represents builder factories. It has three type parameters: `From` indicates
+the type for which this builder factory applies, `Elem` indicates the element
+type of the collection to be built, and `To` indicates the type of
+collection to build. By defining the right implicit
 definitions of builder factories, you can tailor the right typing
 behavior as needed. Take class `BitSet` as an example. Its companion
-object would contain a builder factory of type `CanBuildFrom[BitSet, Int, BitSet]`. This means that when operating on a `BitSet` you can
-construct another `BitSet` provided the type of the collection to build
-is `Int`. If this is not the case, you can always fall back to a
-different implicit builder factory, this time implemented in
+object would contain a builder factory of type `CanBuildFrom[BitSet, Int, BitSet]`.
+This means that when operating on a `BitSet` you can
+construct another `BitSet` provided the element type of the collection to build
+is `Int`. If this is not the case, the compiler will check the superclasses, and
+fall back to the implicit builder factory defined in 
 `mutable.Set`'s companion object. The type of this more general builder
 factory, where `A` is a generic type parameter, is:
 
@@ -273,8 +277,8 @@ one that's appropriate and maximally specific.
 
 So implicit resolution provides the correct static types for tricky
 collection operations such as `map`. But what about the dynamic types?
-Specifically, say you have a list value that has `Iterable` as its
-static type, and you map some function over that value:
+Specifically, say you map some function over a `List` value that has
+`Iterable` as its static type:
 
     scala> val xs: Iterable[Int] = List(1, 2, 3)
     xs: Iterable[Int] = List(1, 2, 3)
@@ -283,7 +287,7 @@ static type, and you map some function over that value:
     ys: Iterable[Int] = List(1, 4, 9)
 
 The static type of `ys` above is `Iterable`, as expected. But its dynamic
-type is (and should be) still `List`! This behavior is achieved by one
+type is (and should still be) `List`! This behavior is achieved by one
 more indirection. The `apply` method in `CanBuildFrom` is passed the
 source collection as argument. Most builder factories for generic
 traversables (in fact all except builder factories for leaf classes)
@@ -294,16 +298,21 @@ resolution to resolve constraints on the types of `map`, and virtual
 dispatch to pick the best dynamic type that corresponds to these
 constraints.
 
-## Integrating new collections ##
+In the current example, the static implicit resolution will pick the
+`Iterable`'s `CanBuildFrom`, which calls `genericBuilder` on the value it
+received as argument. But at runtime, because of virtual dispatch, it is
+`List.genericBuilder` that gets called rather than `Iterable.genericBuilder`,
+and so map builds a `List`.
+
+## Integrating a new collection: RNA sequences ##
 
 What needs to be done if you want to integrate a new collection class,
-so that it can profit from all predefined operations at the right
-types? On the next few pages you'll be walked through two examples
-that do this.
+so that it can profit from all predefined operations with the right
+types? In the next few sections you'll be walked through two examples
+that do this, namely sequences of RNA bases and prefix maps implemented
+with Patricia tries.
 
-### Integrating sequences ###
-
-RNA Bases:
+To start with the first example, we define the four RNA Bases:
 
     abstract class Base
     case object A extends Base
@@ -339,7 +348,7 @@ two-bit values in an integer. The idea, then, is to construct a
 specialized subclass of `Seq[Base]`, which uses this packed
 representation.
 
-#### First version of RNA strands class ####
+### First version of RNA strands class ###
 
     import collection.IndexedSeqLike
     import collection.mutable.{Builder, ArrayBuffer}
@@ -378,7 +387,8 @@ representation.
       def apply(bases: Base*) = fromSeq(bases)
     }
 
-The [RNA strands class listing](#first_version_of_rna_strands_class) above presents the first version of this
+The [RNA strands class listing](#first-version-of-rna-strands-class) above
+presents the first version of this
 class. It will be refined later. The class `RNA1` has a constructor that
 takes an array of `Int`s as its first argument. This array contains the
 packed RNA data, with sixteen bases in each element, except for the
@@ -390,7 +400,8 @@ defines two abstract methods, `length` and `apply`. These need to be
 implemented in concrete subclasses. Class `RNA1` implements `length`
 automatically by defining a parametric field of the same name. It
 implements the indexing method `apply` with the code given in [class
-`RNA1`](#first_version_of_rna_strands_class). Essentially, `apply` first extracts an integer value from the
+`RNA1`](#first-version-of-rna-strands-class). Essentially, `apply` first
+extracts an integer value from the
 `groups` array, then extracts the correct two-bit number from that
 integer using right shift (`>>`) and mask (`&`). The private constants `S`,
 `N`, and `M` come from the `RNA1` companion object. `S` specifies the size of
@@ -425,7 +436,7 @@ simply forwards them as a sequence to `fromSeq`. Here are the two
 creation schemes in action:
 
     scala> val xs = List(A, G, U, A)
-    xs: List[Product with Base] = List(A, G, U, A)
+    xs: List[Product with Serializable with Base] = List(A, G, U, A)
   
     scala> RNA1.fromSeq(xs)
     res1: RNA1 = RNA1(A, G, U, A)
@@ -433,7 +444,7 @@ creation schemes in action:
     scala> val rna1 = RNA1(A, U, G, G, C)
     rna1: RNA1 = RNA1(A, U, G, G, C)
 
-## Adapting the result type of RNA methods ##
+### Adapting the result type of RNA methods ###
 
 Here are some more interactions with the `RNA1` abstraction:
 
@@ -451,11 +462,27 @@ the first three elements of `rna1` might not be. In fact, you see a
 `IndexedSeq[Base]` as static result type and a `Vector` as the dynamic
 type of the result value. You might have expected to see an `RNA1` value
 instead. But this is not possible because all that was done in [class
-`RNA1`](#first_version_of_rna_strands_class) was making `RNA1` extend `IndexedSeq`. Class `IndexedSeq`, on the other
+`RNA1`](#first-version-of-rna-strands-class) was making `RNA1` extend
+`IndexedSeq`. Class `IndexedSeq`, on the other
 hand, has a `take` method that returns an `IndexedSeq`, and that's
 implemented in terms of `IndexedSeq`'s default implementation,
 `Vector`. So that's what you were seeing on the last line of the
 previous interaction.
+
+Now that you understand why things are the way they are, the next
+question should be what needs to be done to change them? One way to do
+this would be to override the `take` method in class `RNA1`, maybe like
+this:
+
+    def take(count: Int): RNA1 = RNA1.fromSeq(super.take(count))
+
+This would do the job for `take`. But what about `drop`, or `filter`, or
+`init`? In fact there are over fifty methods on sequences that return
+again a sequence. For consistency, all of these would have to be
+overridden. This looks less and less like an attractive
+option. Fortunately, there is a much easier way to achieve the same
+effect, as shown in the next section.
+
 
 ### Second version of RNA strands class ###
 
@@ -472,23 +499,12 @@ previous interaction.
       def apply(idx: Int): Base = // as before
     }
 
-Now that you understand why things are the way they are, the next
-question should be what needs to be done to change them? One way to do
-this would be to override the `take` method in class `RNA1`, maybe like
-this:
-
-    def take(count: Int): RNA1 = RNA1.fromSeq(super.take(count))
-
-This would do the job for `take`. But what about `drop`, or `filter`, or
-`init`? In fact there are over fifty methods on sequences that return
-again a sequence. For consistency, all of these would have to be
-overridden. This looks less and less like an attractive
-option. Fortunately, there is a much easier way to achieve the same
-effect. The RNA class needs to inherit not only from `IndexedSeq`, but
+The RNA class needs to inherit not only from `IndexedSeq`, but
 also from its implementation trait `IndexedSeqLike`. This is shown in
 the above listing of class `RNA2`. The new implementation differs from
 the previous one in only two aspects. First, class `RNA2` now also
-extends from `IndexedSeqLike[Base, RNA2]`. The `IndexedSeqLike` trait
+extends `IndexedSeqLike[Base, RNA2]`. Second, it provides a builder for
+RNA strands. The `IndexedSeqLike` trait
 implements all concrete methods of `IndexedSeq` in an extensible
 way. For instance, the return type of methods like `take`, `drop`, `filter`,
 or `init` is the second type parameter passed to class `IndexedSeqLike`,
@@ -528,14 +544,17 @@ this case it detracts more than it helps. What remains is that a
 method `newBuilder` with result type `Builder[Base, RNA2]` needed to be
 defined, but a method `newBuilder` with result type
 `Builder[Base,IndexedSeq[Base]]` was found. The latter does not override
-the former. The first method, whose result type is `Builder[Base, RNA2]`, is an abstract method that got instantiated at this type in
-[class `RNA2`](#second_version_of_rna_strands_class) by passing the `RNA2` type parameter to `IndexedSeqLike`. The
+the former. The first method, whose result type is `Builder[Base, RNA2]`,
+is an abstract method that got instantiated at this type in
+[class `RNA2`](#second-version-of-rna-strands-class) by passing the
+`RNA2` type parameter to `IndexedSeqLike`. The
 second method, of result type `Builder[Base,IndexedSeq[Base]]`, is
 what's provided by the inherited `IndexedSeq` class. In other words, the
 `RNA2` class is invalid without a definition of `newBuilder` with the
 first result type.
 
-With the refined implementation of the [`RNA2` class](#second_version_of_rna_strands_class), methods like `take`,
+With the refined implementation of the [`RNA2` class](#second-version-of-rna-strands-class),
+methods like `take`,
 `drop`, or `filter` work now as expected:
 
     scala> val rna2 = RNA2(A, U, G, G, C)
@@ -547,7 +566,7 @@ With the refined implementation of the [`RNA2` class](#second_version_of_rna_str
     scala> rna2 filter (U !=)
     res6: RNA2 = RNA2(A, G, G, C)
 
-## Dealing with map and friends ##
+### Dealing with map and friends ###
 
 However, there is another class of methods in collections that are not
 dealt with yet. These methods do not always return the collection type
@@ -563,17 +582,15 @@ them you would expect this (e.g., `flatMap`, `collect`), but for others
 you might not. For instance, the append method, `++`, also might return
 a result of different type as its arguments--appending a list of
 `String` to a list of `Int` would give a list of `Any`. How should these
-methods be adapted to RNA strands? Ideally we'd expect that mapping
-bases to bases over an RNA strand would yield again an RNA strand:
+methods be adapted to RNA strands? The desired behavior would be to get
+back an RNA strand when mapping bases to bases or appending two RNA strands
+with `++`:
 
     scala> val rna = RNA(A, U, G, G, C)
     rna: RNA = RNA(A, U, G, G, C)
   
     scala> rna map { case A => U case b => b }
     res7: RNA = RNA(U, U, G, G, C)
-
-Likewise, appending two RNA strands with `++` should yield again
-another RNA strand:
 
     scala> rna ++ rna
     res8: RNA = RNA(A, U, G, G, C, A, U, G, G, C)
@@ -592,8 +609,9 @@ yield a general sequence, but it cannot yield another RNA strand.
       Vector(A, U, G, G, C, missing, data)
 
 This is what you'd expect in the ideal case. But this is not what the
-[`RNA2` class](#second_version_of_rna_strands_class) provides. In fact, if you ran the first two examples above
-with instances of this class you would obtain:
+[`RNA2` class](#second-version-of-rna-strands-class) provides. In fact, all
+examples will return instances of `Vector`, not just the last two. If you run
+the first three commands above with instances of this class you obtain:
 
     scala> val rna2 = RNA2(A, U, G, G, C)
     rna2: RNA2 = RNA2(A, U, G, G, C)
@@ -605,7 +623,7 @@ with instances of this class you would obtain:
     res1: IndexedSeq[Base] = Vector(A, U, G, G, C, A, U, G, G, C)
 
 So the result of `map` and `++` is never an RNA strand, even if the
-element type of the generated collection is a `Base`. To see how to do
+element type of the generated collection is `Base`. To see how to do
 better, it pays to have a close look at the signature of the `map`
 method (or of `++`, which has a similar signature). The `map` method is
 originally defined in class `scala.collection.TraversableLike` with the
@@ -624,11 +642,21 @@ function, which is also the element type of the new collection. The
 the new collection that gets created.
 
 How is the `That` type determined? In fact it is linked to the other
-types by an implicit parameter `cbf`, of type `CanBuildFrom[Repr, B, That]`. These `CanBuildFrom` implicits are defined by the individual
-collection classes. In essence, an implicit value of type
-`CanBuildFrom[From, Elem, To]` says: "Here is a way, given a collection
-of type `From`, to build with elements of type `Elem` a collection of type
-`To`."
+types by an implicit parameter `cbf`, of type `CanBuildFrom[Repr, B, That]`.
+These `CanBuildFrom` implicits are defined by the individual
+collection classes. Recall that an implicit value of type
+`CanBuildFrom[Repr, B, That]` says: "Here is a way, given a collection
+of type `Repr` and new elements of type `B`, to build a collection of type
+`That` containing those elements".
+
+Now the behavior of `map` and `++` on `RNA2` sequences becomes
+clearer. There is no `CanBuildFrom` instance that creates `RNA2`
+sequences, so the next best available `CanBuildFrom` was found in the
+companion object of the inherited trait `IndexedSeq`. That implicit
+creates `Vector`s (recall that `Vector` is the default implementation
+of `IndexedSeq`), and that's what you saw when applying `map` to
+`rna2`.
+
 
 ### Final version of RNA strands class ###
 
@@ -688,25 +716,19 @@ of type `From`, to build with elements of type `Elem` a collection of type
         }
     }
 
-Now the behavior of `map` and `++` on `RNA2` sequences becomes
-clearer. There is no `CanBuildFrom` instance that creates `RNA2`
-sequences, so the next best available `CanBuildFrom` was found in the
-companion object of the inherited trait `IndexedSeq`. That implicit
-creates `IndexedSeq`s, and that's what you saw when applying `map` to
-`rna2`.
-
 To address this shortcoming, you need to define an implicit instance
 of `CanBuildFrom` in the companion object of the RNA class. That
 instance should have type `CanBuildFrom[RNA, Base, RNA]`. Hence, this
 instance states that, given an RNA strand and a new element type `Base`,
 you can build another collection which is again an RNA strand. The two
-listings above on [class `RNA`](#final_version_of_rna_strands_class) and
-[its companion object](#final_version_of_rna_companion_object) show the
-details. Compared to [class `RNA2`](#second_version_of_rna_strands_class) there are two important
+listings above of [class `RNA`](#final-version-of-rna-strands-class) and
+[its companion object](#final-version-of-rna-companion-object) show the
+details. Compared to [class `RNA2`](#second-version-of-rna-strands-class)
+there are two important
 differences. First, the `newBuilder` implementation has moved from the
 RNA class to its companion object. The `newBuilder` method in class `RNA`
 simply forwards to this definition. Second, there is now an implicit
-`CanBuildFrom` value in object `RNA`. To create such an object you need to
+`CanBuildFrom` value in object `RNA`. To create this value you need to
 define two `apply` methods in the `CanBuildFrom` trait. Both create a new
 builder for an `RNA` collection, but they differ in their argument
 list. The `apply()` method simply creates a new builder of the right
@@ -718,14 +740,15 @@ is a final class, so any receiver of static type `RNA` also has `RNA` as
 its dynamic type. That's why `apply(from)` also simply calls `newBuilder`,
 ignoring its argument.
 
-That is it. The final [`RNA` class](#final_version_of_rna_strands_class) implements all collection methods at
-their natural types. Its implementation requires a little bit of
+That is it. The final [`RNA` class](#final-version-of-rna-strands-class)
+implements all collection methods at
+their expected types. Its implementation requires a little bit of
 protocol. In essence, you need to know where to put the `newBuilder`
 factories and the `canBuildFrom` implicits. On the plus side, with
 relatively little code you get a large number of methods automatically
 defined. Also, if you don't intend to do bulk operations like `take`,
 `drop`, `map`, or `++` on your collection you can choose to not go the extra
-length and stop at the implementation shown in for [class `RNA1`](#first_version_of_rna_strands_class).
+length and stop at the implementation shown in for [class `RNA1`](#first-version-of-rna-strands-class).
 
 The discussion so far centered on the minimal amount of definitions
 needed to define new sequences with methods that obey certain
@@ -746,19 +769,21 @@ immediately applies the given function to all bases contained in
 it. So the effort for array selection and bit unpacking is much
 reduced.
 
-## Integrating new sets and maps ##
+## Integrating a new prefix map ##
 
 As a second example you'll learn how to integrate a new kind of map
 into the collection framework. The idea is to implement a mutable map
 with `String` as the type of keys by a "Patricia trie". The term
 *Patricia* is in fact an abbreviation for "Practical Algorithm to
-Retrieve Information Coded in Alphanumeric." The idea is to store a
-set or a map as a tree where subsequent character in a search key
-determines uniquely a descendant tree. For instance a Patricia trie
-storing the three strings "abc", "abd", "al", "all", "xy" would look
+Retrieve Information Coded in Alphanumeric" and *trie* comes from
+re*trie*val (a trie is also called a radix tree or prefix tree).
+The idea is to store a set or a map as a tree where subsequent
+characters in a search key
+uniquely determine a path through the tree. For instance a Patricia trie
+storing the strings "abc", "abd", "al", "all" and "xy" would look
 like this:
 
-A sample patricia tree:
+A sample patricia trie:
 <img src="{{ site.baseurl }}/resources/images/patricia.png" width="550">
 
 To find the node corresponding to the string "abc" in this trie,
@@ -769,7 +794,28 @@ key is stored in the nodes that can be reached by the key. If it is a
 set, you simply store a marker saying that the node is present in the
 set.
 
-An implementation of prefix maps with Patricia tries:
+Patricia tries support very efficient lookups and updates. Another
+nice feature is that they support selecting a subcollection by giving
+a prefix. For instance, in the patricia tree above you can obtain the
+sub-collection of all keys that start with an "a" simply by following
+the "a" link from the root of the tree.
+
+Based on these ideas we will now walk you through the implementation
+of a map that's implemented as a Patricia trie. We call the map a
+`PrefixMap`, which means that it provides a method `withPrefix` that
+selects a submap of all keys starting with a given prefix. We'll first
+define a prefix map with the keys shown in the running example:
+
+    scala> val m = PrefixMap("abc" -> 0, "abd" -> 1, "al" -> 2, 
+      "all" -> 3, "xy" -> 4)
+    m: PrefixMap[Int] = Map((abc,0), (abd,1), (al,2), (all,3), (xy,4))
+
+Then calling `withPrefix` on `m` will yield another prefix map:
+
+    scala> m withPrefix "a"
+    res14: PrefixMap[Int] = Map((bc,0), (bd,1), (l,2), (ll,3))
+
+### Patricia trie implementation ###
 
     import collection._
       
@@ -815,30 +861,11 @@ An implementation of prefix maps with Patricia tries:
       override def empty = new PrefixMap[T]
     }
 
-Patricia tries support very efficient lookups and updates. Another
-nice feature is that they support selecting a subcollection by giving
-a prefix. For instance, in the patricia tree above you can obtain the
-sub-collection of all keys that start with an "a" simply by following
-the "a" link from the root of the tree.
 
-Based on these ideas we will now walk you through the implementation
-of a map that's implemented as a Patricia trie. We call the map a
-`PrefixMap`, which means that it provides a method `withPrefix` that
-selects a submap of all keys starting with a given prefix. We'll first
-define a prefix map with the keys shown in the running example:
-
-    scala> val m = PrefixMap("abc" -> 0, "abd" -> 1, "al" -> 2, 
-      "all" -> 3, "xy" -> 4)
-    m: PrefixMap[Int] = Map((abc,0), (abd,1), (al,2), (all,3), (xy,4))
-
-Then calling `withPrefix` on `m` will yield another prefix map:
-
-    scala> m withPrefix "a"
-    res14: PrefixMap[Int] = Map((bc,0), (bd,1), (l,2), (ll,3))
-
-The previous listing shows the definition of `PrefixMap`. This class is
-parameterized with the type of associated values `T`, and extends
-`mutable.Map[String, T]` and `mutable.MapLike[String, T, PrefixMap[T]]`. You have seen this pattern already for sequences in the
+The previous listing shows the definition of `PrefixMap`. The map has
+keys of type `String` and the values are of parametric type `T`. It extends
+`mutable.Map[String, T]` and `mutable.MapLike[String, T, PrefixMap[T]]`.
+You have seen this pattern already for sequences in the
 RNA strand example; then as now inheriting an implementation class
 such as `MapLike` serves to get the right result type for
 transformations such as `filter`.
@@ -849,7 +876,7 @@ node. It is initialized to `None`. The `suffixes` field contains a map
 from characters to `PrefixMap` values. It is initialized to the empty
 map.
 
-You might ask why did we pick an immutable map as the implementation
+You might ask why we picked an immutable map as the implementation
 type for `suffixes`? Would not a mutable map have been more standard,
 since `PrefixMap` as a whole is also mutable? The answer is that
 immutable maps that contain only a few elements are very efficient in
@@ -865,15 +892,17 @@ in an immutable map is likely to be more efficient.
 Now have a look at the first method that needs to be implemented for a
 map: `get`. The algorithm is as follows: To get the value associated
 with the empty string in a prefix map, simply select the optional
-`value` stored in the root of the tree. Otherwise, if the key string is
+`value` stored in the root of the tree (the current map).
+Otherwise, if the key string is
 not empty, try to select the submap corresponding to the first
 character of the string. If that yields a map, follow up by looking up
 the remainder of the key string after its first character in that
 map. If the selection fails, the key is not stored in the map, so
-return with `None`. The combined selection over an option value is
-elegantly expressed using `flatMap`. When applied to an optional value,
-`ov`, and a closure, `f`, which in turn returns an optional value, `ov flatMap f` will succeed if both `ov` and `f` return a defined
-value. Otherwise `ov flatMap f` will return `None`.
+return with `None`. The combined selection over an option value `opt` is
+elegantly expressed using `opt.flatMap(x => f(x))`. When applied to an
+optional value that is `None`, it returns `None`. Otherwise `opt` is
+`Some(x)` and the function `f` is applied to the encapsulated value `x`,
+yielding a new option, which is returned by the flatmap.
 
 The next two methods to implement for a mutable map are `+=` and `-=`. In
 the implementation of `PrefixMap`, these are defined in terms of two
@@ -906,7 +935,21 @@ makes use of the fact that `Option` values define an iterator method
 that returns either no element, if the option value is `None`, or
 exactly one element `x`, if the option value is `Some(x)`.
 
-The companion object for prefix maps:
+Note that there is no `newBuilder` method defined in `PrefixMap`. There is
+no need to, because maps and sets come with default builders, which
+are instances of class `MapBuilder`. For a mutable map the default
+builder starts with an empty map and then adds successive elements
+using the map's `+=` method. For immutable maps, the non-destructive
+element addition method `+` is used instead of method `+=`. Sets work
+in the same way.
+
+However, in all these cases, to build the right kind of colletion
+you need to start with an empty collection of that kind. This is
+provided by the `empty` method, which is the last method defined in
+`PrefixMap`. This method simply returns a fresh `PrefixMap`.
+
+
+### The companion object for prefix maps ###
 
     import scala.collection.mutable.{Builder, MapBuilder}
     import scala.collection.generic.CanBuildFrom
@@ -931,19 +974,6 @@ The companion object for prefix maps:
           }
     }
 
-Note that there is no `newBuilder` method defined in `PrefixMap`. There is
-no need to, because maps and sets come with default builders, which
-are instances of class `MapBuilder`. For a mutable map the default
-builder starts with an empty map and then adds successive elements
-using the map's `+=` method. Mutable sets behave the same. The default
-builders for immutable maps and sets use the non-destructive element
-addition method `+`, instead of method `+=`.
-
-However, in all these cases, to build the right kind of set or map,
-you need to start with an empty set or map of this kind. This is
-provided by the `empty` method, which is the last method defined in
-`PrefixMap`. This method simply returns a fresh `PrefixMap`.
-
 We'll now turn to the companion object `PrefixMap`. In fact it is not
 strictly necessary to define this companion object, as class `PrefixMap`
 can stand well on its own. The main purpose of object `PrefixMap` is to
@@ -956,27 +986,30 @@ it makes sense to define them here, too. With the two methods, you can
 write `PrefixMap` literals like you do for any other collection:
 
     scala> PrefixMap("hello" -> 5, "hi" -> 2)
-    res0: PrefixMap[Int] = Map((hello,5), (hi,2))
+    res0: PrefixMap[Int] = Map(hello -> 5, hi -> 2)
       
     scala> PrefixMap.empty[String]
     res2: PrefixMap[String] = Map()
 
 The other member in object `PrefixMap` is an implicit `CanBuildFrom`
 instance. It has the same purpose as the `CanBuildFrom` definition in
-the last section: to make methods like `map` return the best possible
-type. For instance, consider `map`ping a function over the key/value
+the [`RNA` companion object](#final-version-of-rna-companion-object)
+from the last section: to make methods like `map` return the best possible
+type. For instance, consider mapping a function over the key/value
 pairs of a `PrefixMap`. As long as that function produces pairs of
 strings and some second type, the result collection will again be a
 `PrefixMap`. Here's an example:
 
     scala> res0 map { case (k, v) => (k + "!", "x" * v) }
-    res8: PrefixMap[String] = Map((hello!,xxxxx), (hi!,xx))
+    res8: PrefixMap[String] = Map(hello! -> xxxxx, hi! -> xx)
 
 The given function argument takes the key/value bindings of the prefix
 map `res0` and produces pairs of strings. The result of the `map` is a
 `PrefixMap`, this time with value type `String` instead of `Int`. Without
 the `canBuildFrom` implicit in `PrefixMap` the result would just have been
-a general mutable map, not a prefix map.
+a general mutable map, not a prefix map. For convenience, the `PrefixMap`
+object defines a `newBuilder` method, but it still just uses the
+default `MapBuilder`.
 
 ## Summary ##
 
@@ -992,8 +1025,8 @@ into the framework you need to pay attention to the following points:
    companion object.
  
 You have now seen how Scala's collections are built and how you can
-build new kinds of collections. Because of Scala's rich support for
-abstraction, each new collection type can have a large number of
+add new kinds of collections. Because of Scala's rich support for
+abstraction, each new collection type has a large number of
 methods without having to reimplement them all over again.
 
 ### Acknowledgement ###


### PR DESCRIPTION
* Fixed typos
* Fixed all links (anchors have dashes instead of underscores)
* TraversableLike is a trait, not a class
* Reordered some sections so that titles make more sense
* Restructured outline (level #### is currently displayed with both a dot and a square, so removed it)
* Added a few clarifications
