### PR TITLE
Fix a couple formatting errors in the style guide

### DIFF
--- a/style/naming-conventions.md
+++ b/style/naming-conventions.md
@@ -255,7 +255,7 @@ final, immutable and it belongs to a package object or an object,
 it may be considered a constant (similar to Java's `static final` members):
 
     object Container {
-        val MyConstant = ...
+      val MyConstant = ...
     }
 
 The value: `Pi` in `scala.math` package is another example of such a constant.

--- a/style/types.md
+++ b/style/types.md
@@ -98,7 +98,7 @@ For example:
     def map[B](f: A => B) = ...
 
 Specifically, the parentheses may be omitted from the parameter type.
-Thus, we did *not* declare `f` to be of type "`(A) => B`, as this would
+Thus, we did *not* declare `f` to be of type `(A) => B`, as this would
 have been needlessly verbose. Consider the more extreme example:
 
     // wrong!


### PR DESCRIPTION
In "Naming conventions" a `val` was indented 4 spaces instead of 2, and in "Types" there was a quotation mark out of place.