### PR TITLE
Move "Common methods" before "Automatically imported methods"

### DIFF
--- a/tutorials/FAQ/finding-symbols.md
+++ b/tutorials/FAQ/finding-symbols.md
@@ -11,8 +11,8 @@ outof: 9
 Let's divide the operators, for the purpose of teaching, into **four categories**:
 
 * Keywords/reserved symbols
-* Automatically imported methods
 * Common methods
+* Automatically imported methods
 * Syntactic sugars/composition
 
 And let's see some arbitrary examples:
@@ -28,10 +28,11 @@ And let's see some arbitrary examples:
 
 The exact meaning of most of these methods depend on the class that is defining
 them. For example, `<=` on `Int` means _"less than or equal to"_, but it might
-mean something else in another class.  `::` is probably the method defined on
-`List` but it _could_ also be the object of the same name.
+mean something else in another class.  `::` in an expression is probably the method of the class
+`List` but it _could_ also be the object of the same name (and in a pattern it
+definitely is).
 
-So, let's see them.
+So, let's discuss these categories.
 
 Keywords/reserved symbols
 -------------------------
@@ -80,19 +81,52 @@ widely used, and has different meanings depending on the context. Here's a sampl
     f(xs: _*)         // Sequence xs is passed as multiple parameters to f(ys: T*)
     case Seq(xs @ _*) // Identifier xs is bound to the whole matched sequence
 
+Common methods
+--------------
+
+Many symbols are simply methods of a class, a trait, or an object. For instance, if you do
+
+    List(1, 2) ++ List(3, 4)
+
+You'll find the method `++` right on the ScalaDoc for [List][5]. However,
+there's one convention that you must be aware when searching for methods.
+Methods ending in colon (`:`) bind _to the right_ instead of the left. In other
+words, while the above method call is equivalent to:
+
+    List(1, 2).++(List(3, 4))
+
+If I had, instead `1 :: List(2, 3)`, that would be equivalent to:
+
+    List(2, 3).::(1)
+
+So you need to look at the type found _on the right_ when looking for methods
+ending in colon. Consider, for instance:
+
+    1 +: List(2, 3) :+ 4
+
+The first method (`+:`) binds to the right, and is found on `List`. The second
+method (`:+`) is just a normal method, and binds to the left -- again, on
+`List`.
+
+If you aren't sure what the type of the receiver is, you can look up the symbol
+on the ScalaDoc [index page for identifiers not starting with letters][2] (for
+standard Scala library; of course, third-party libraries can add their own
+symbolic methods, for which you should look at the corresponding page of _their_
+ScalaDoc).
+
 Automatically imported methods
 ------------------------------
 
-If you did not find the symbol you are looking for in the list above, then
+If you did not find the symbol you are looking for in the list of reserved symbols, then
 it must be a method, or part of one. But, often, you'll see some symbol and the
 documentation for the class will not have that method. When this happens,
 either you are looking at a composition of one or more methods with something
 else, or the method has been imported into scope, or is available through an
 imported implicit conversion.
 
-These can also be found in ScalaDoc's [index][2].
+These can also be found in ScalaDoc's [index][2], as mentioned above.
 
-Every Scala code has three automatic imports:
+All Scala code has three automatic imports:
 
     // Not necessarily in this order
     import java.lang._
@@ -119,33 +153,6 @@ object of type that is receiving the method. For example:
 In the above case, `->` is defined in the class [`ArrowAssoc`][4] through the
 method `any2ArrowAssoc` that takes an object of type `A`, where `A` is an
 unbounded type parameter to the same method.
-
-Common methods
---------------
-
-Many symbols are simply methods on a class. For instance, if you do
-
-    List(1, 2) ++ List(3, 4)
-
-You'll find the method `++` right on the ScalaDoc for [List][5]. However,
-there's one convention that you must be aware when searching for methods.
-Methods ending in colon (`:`) bind _to the right_ instead of the left. In other
-words, while the above method call is equivalent to:
-
-    List(1, 2).++(List(3, 4))
-
-If I had, instead `1 :: List(2, 3)`, that would be equivalent to:
-
-    List(2, 3).::(1)
-
-So you need to look at the type found _on the right_ when looking for methods
-ending in colon. Consider, for instance:
-
-    1 +: List(2, 3) :+ 4
-
-The first method (`+:`) binds to the right, and is found on `List`. The second
-method (`:+`) is just a normal method, and binds to the left -- again, on
-`List`.
 
 Syntactic sugars/composition
 -----------------------------

--- a/tutorials/FAQ/finding-symbols.md
+++ b/tutorials/FAQ/finding-symbols.md
@@ -8,29 +8,27 @@ partof: FAQ
 num: 1
 outof: 9
 ---
-Let's divide the operators, for the purpose of teaching, into **four categories**:
+We can divide the operators in Scala, for the purpose of teaching, into four categories:
 
 * Keywords/reserved symbols
-* Common methods
-* Automatically imported methods
+* Normal methods or values
+* Methods provided by implicit conversion
 * Syntactic sugars/composition
 
 And let's see some arbitrary examples:
 
-    ->    // Automatically imported method
     <-    // Keyword
-    ||=   // Syntactic sugar
-    ++=   // Syntactic sugar/composition or common method
+    ->    // Method provided by implicit conversion
     <=    // Common method
-    _+_   // Keyword/composition
+    ++=   // Can be a common method or syntactic sugar involving ++ method
     ::    // Common method or object
-    :+=   // Common method
+    _+_   // Not really a single operator; it's parsed as _ + _
 
-The exact meaning of most of these methods depend on the class that is defining
-them. For example, `<=` on `Int` means _"less than or equal to"_, but it might
+The exact meaning of most of these methods depends on the class they are defined
+on. For example, `<=` on `Int` means _"less than or equal to"_, but it might
 mean something else in another class.  `::` in an expression is probably the method of the class
-`List` but it _could_ also be the object of the same name (and in a pattern it
-definitely is).
+`List` but it can also refer to the object of the same name (and in a pattern it
+definitely does).
 
 So, let's discuss these categories.
 
@@ -108,14 +106,21 @@ The first method (`+:`) binds to the right, and is found on `List`. The second
 method (`:+`) is just a normal method, and binds to the left -- again, on
 `List`.
 
+If the name ends in `=`, look for the method called the same without `=` and
+read the last section.
+
 If you aren't sure what the type of the receiver is, you can look up the symbol
 on the ScalaDoc [index page for identifiers not starting with letters][2] (for
 standard Scala library; of course, third-party libraries can add their own
 symbolic methods, for which you should look at the corresponding page of _their_
 ScalaDoc).
 
-Automatically imported methods
-------------------------------
+Types and objects can also have symbolic names; in particular, it should be mentioned
+that for types with two type parameters the name can be written _between_ parameters,
+so that e.g. `Int <:< Any` is the same as `<:<[Int, Any]`.
+
+Methods provided by implicit conversion
+---------------------------------------
 
 If you did not find the symbol you are looking for in the list of reserved symbols, then
 it must be a method, or part of one. But, often, you'll see some symbol and the
@@ -133,26 +138,28 @@ All Scala code has three automatic imports:
     import scala._
     import scala.Predef._
 
-The first two only make classes and singleton objects available. The third one
-contains all implicit conversions and imported methods, since [`Predef`][3] is
-an object itself.
+The first two only make classes and singleton objects available, none of which
+look like operators. [`Predef`][3] is the only interesting one for this post.
 
-Looking inside `Predef` quickly shows some symbols:
+Looking inside `Predef` shows some symbolic names:
 
     class <:<
     class =:=
-    object <%<
     object =:=
+    object <%< // removed in Scala 2.10
+    def ???
 
-Any other symbol will be made available through an _implicit conversion_. Just
-look at the methods tagged with `implicit` that receive, as parameter, an
-object of type that is receiving the method. For example:
+There is also `::`, which doesn't appear in the ScalaDoc, but is mentioned in the comments.
+In addition, `Predef` makes some methods available through _implicit conversions_. Just
+look at the methods and classes with `implicit` modifier that receive, as parameter, an
+object of type that is receiving the method. For example, consider `"a" -> 1`. We need
+to look for an implicit which works on `"a"`, and so it can take `String`, one of its
+supertypes (`AnyRef` or `Any`) or a type parameter. In this case, we find
+`implicit final class ArrowAssoc[A](private val self: A)` which makes this implicit
+avaialable on all types.
 
-    "a" -> 1  // Look for an implicit from String, AnyRef, Any or type parameter
-
-In the above case, `->` is defined in the class [`ArrowAssoc`][4] through the
-method `any2ArrowAssoc` that takes an object of type `A`, where `A` is an
-unbounded type parameter to the same method.
+Other implicit conversions may be visible in your scope depending on imports, extended types or
+self-type annotations. See [Finding implicits](tutorials/FAQ/finding-implicits.md) for details.
 
 Syntactic sugars/composition
 -----------------------------
@@ -171,17 +178,16 @@ So, here's a few syntactic sugars that may hide a method:
       def unapply(n: Int) = if (arr.indices contains n) Some(arr(n)) else None
     }
 
-    var ex = new Example
-    println(ex(0))  // calls apply(0)
-    ex(0) = 2       // calls update(0, 2)
-    ex.b = 3        // calls b_=(3)
-    val ex(c) = 2   // calls unapply(2) and assigns result to c
-    ex += 1         // substituted for ex = ex + 1
+    val ex = new Example
+    println(ex(0))  // means ex.apply(0)
+    ex(0) = 2       // means ex.update(0, 2)
+    ex.b = 3        // means ex.b_=(3)
+    val ex(c) = 2   // calls ex.unapply(2) and assigns result to c, if it's Some; throws MatchError if it's None
+    ex += 1         // means ex = ex + 1; if Example had a += method, it would be used instead
 
-The last one is interesting, because *any* symbolic method can be combined to
-form an assignment-like method that way.
+The last one is interesting, because *any* symbolic method can be combined with `=` in that way.
 
-And, of course, there's various combinations that can appear in code:
+And, of course, all of the above can be combined in various combinations, e.g.
 
     (_+_) // An expression, or parameter, that is an anonymous function with
           // two parameters, used exactly where the underscores appear, and


### PR DESCRIPTION
This moves the more common case earlier, and looking up documentation is discussed
before what to do when it isn't found. Also makes the Scaladoc link more visible, and
mentions third-party libraries explicitly.