### PR TITLE
fix: add a new line before the bullet points

### DIFF
--- a/tutorials/tour/implicit-parameters.md
+++ b/tutorials/tour/implicit-parameters.md
@@ -13,6 +13,7 @@ tutorial-previous: explicitly-typed-self-references
 A method with _implicit parameters_ can be applied to arguments just like a normal method. In this case the implicit label has no effect. However, if such a method misses arguments for its implicit parameters, such arguments will be automatically provided.
 
 The actual arguments that are eligible to be passed to an implicit parameter fall into two categories:
+
 * First, eligible are all identifiers x that can be accessed at the point of the method call without a prefix and that denote an implicit definition or an implicit parameter.
 * Second, eligible are also all members of companion modules of the implicit parameter's type that are labeled implicit.
 


### PR DESCRIPTION
I think this change will fix http://docs.scala-lang.org/tutorials/tour/implicit-parameters.html