### PR TITLE
Update TraitsTest sample to extend App instead of Application

### DIFF
--- a/es/tutorials/tour/traits.md
+++ b/es/tutorials/tour/traits.md
@@ -28,7 +28,7 @@ Este trait consiste de dos métodos `isSimilar` y `isNotSimilar`. Mientras `isSi
         obj.isInstanceOf[Point] &&
         obj.asInstanceOf[Point].x == x
     }
-    object TraitsTest extends Application {
+    object TraitsTest extends App {
       val p1 = new Point(2, 3)
       val p2 = new Point(2, 4)
       val p3 = new Point(3, 3)

--- a/ko/tutorials/tour/traits.md
+++ b/ko/tutorials/tour/traits.md
@@ -26,7 +26,7 @@ language: ko
         obj.isInstanceOf[Point] &&
         obj.asInstanceOf[Point].x == x
     }
-    object TraitsTest extends Application {
+    object TraitsTest extends App {
       val p1 = new Point(2, 3)
       val p2 = new Point(2, 4)
       val p3 = new Point(3, 3)

--- a/tutorials/tour/traits.md
+++ b/tutorials/tour/traits.md
@@ -27,7 +27,7 @@ This trait consists of two methods `isSimilar` and `isNotSimilar`. While `isSimi
         obj.isInstanceOf[Point] &&
         obj.asInstanceOf[Point].x == x
     }
-    object TraitsTest extends Application {
+    object TraitsTest extends App {
       val p1 = new Point(2, 3)
       val p2 = new Point(2, 4)
       val p3 = new Point(3, 3)


### PR DESCRIPTION
`scala.Application` has been deprecated since version 2.9.0 and is no
longer available as of 2.11.0.