### PR TITLE
Add Algolia search on header bar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ _site
 .settings
 *~
 vendor/bundle
+.idea/

--- a/_includes/footerbar.txt
+++ b/_includes/footerbar.txt
@@ -34,3 +34,9 @@
 		</p>		
 	</div>
 </div>
+
+<!-- search -->
+<script src="//cdn.jsdelivr.net/algoliasearch/3/algoliasearch.min.js"></script>
+<script src="//cdn.jsdelivr.net/autocomplete.js/0/autocomplete.min.js"></script>
+<script src="{{ site.baseurl }}/resources/javascript/searchbar.js" type="text/javascript" ></script>
+

--- a/_includes/header.txt
+++ b/_includes/header.txt
@@ -153,4 +153,4 @@
     </style>
 
 </head>
-  <body onload="styleCode()">
+<body onload="styleCode()">

--- a/_includes/topbar.txt
+++ b/_includes/topbar.txt
@@ -36,12 +36,12 @@
 
                 <li><a href="{{ site.baseurl }}/contribute.html">Contribute</a></li>
                 <li><a href="{{ site.baseurl }}/sips">SIPs/SLIPs</a></li>
-          </ul>
-          <form method="get" id="searchform" action="{{ site.baseurl }}/search.html">
-            <input type="text" placeholder="Search"  class="field" name="q" id="q"/>
-          </form>
-           </li>
-          </ul>
+                <li>
+                    <form id="searchform" action="#">
+                        <input type="text" placeholder="Search in documentation..." class="field" name="q" id="q"/>
+                    </form>
+                </li>
+            </ul>
         </div>
     </div>
 </div>

--- a/resources/javascript/searchbar.js
+++ b/resources/javascript/searchbar.js
@@ -1,9 +1,9 @@
-(function() {
+(function($) {
     var template =
         '<div class="aa-dataset-a">' +
         '</div>' +
         '<div class="branding-footer">' +
-        '<div class="branding"><span>Powered by</span><a target="_blank" href="https://algolia.com"><img src="https://www.algolia.com/assets/algolia128x40.png"/></a></div>' +
+        '<div class="branding"><span>Powered by</span><a target="_blank" href="https://www.algolia.com/?utm_source=scaladocs"><img src="https://www.algolia.com/assets/algolia128x40.png"/></a></div>' +
         '</div>';
 
     var client = algoliasearch('BH4D9OD16A', '3403ae7bb4cb839fba71e2fae9ab1534');
@@ -14,6 +14,8 @@
         return string.charAt(0).toUpperCase() + string.slice(1);
     };
 
+    var hitsSource = autocomplete.sources.hits(index, { hitsPerPage: 7, tagFilters: [ 'en' ], numericFilters: 'importance>0' });
+
     autocomplete('#q', {
         hint: false,
         debug: false,
@@ -22,20 +24,58 @@
         }
     }, [
         {
-            source: autocomplete.sources.hits(index, { hitsPerPage: 5, tagFilters: [ 'en' ], numericFilters: 'importance>0' }),
+            source: function(query, callback) {
+                hitsSource(query, function(suggestions) {
+                    var categories = {};
+                    suggestions.forEach(function(suggestion) {
+                        var enIndex = suggestion._tags.indexOf('en');
+                        if(enIndex > -1) {
+                            suggestion._tags.splice(enIndex, 1);
+                        }
+                        categories[suggestion._tags[0]] = categories[suggestion._tags[0]] || []
+                        categories[suggestion._tags[0]].push(suggestion)
+                    });
+
+                    categories = $.map(Object.keys(categories).sort(), function(categoryName) {
+                        var items = categories[categoryName];
+                        items[0].isCategoryHeader = true;
+                        items[0].categoryName = capitalize(categoryName);
+
+                        return items;
+                    });
+                    callback(categories);
+                });
+            },
             name: 'a',
             displayKey: 'title',
             templates: {
                 suggestion: function(suggestion) {
+                    var html = [];
+                    if(suggestion.isCategoryHeader) {
+                        html.push('<div class="suggestion-category">' + suggestion.categoryName + '</div>');
+                    }
+
+                    var highlight = suggestion._highlightResult || {};
+                    var snippet = suggestion._snippetResult || {};
+                    var title = highlight.title.value;
+                    var text = '';
                     for(var i = 0 ; i < ATTRIBUTES.length ; i++) {
-                        if(suggestion._highlightResult[ATTRIBUTES[i]] !== undefined) {
-                            return '<span class="title"><strong>' + capitalize(suggestion._tags[1]) + '</strong>: ' + suggestion._highlightResult.title.value + '</span><span class="text">' + suggestion._highlightResult[ATTRIBUTES[i]].value + '</span>';
+                        if(highlight[ATTRIBUTES[i]] !== undefined) {
+                            text = highlight[ATTRIBUTES[i]].value;
+                            text = (snippet[ATTRIBUTES[i]] || {}).value || text;
+                            break;
                         }
                     }
+
+                    html.push('  <div class="suggestion-content">');
+                    html.push('    <div class="suggestion-title">' + title  + '</div>');
+                    html.push('    <div class="suggestion-text">' + text + '</div>');
+                    html.push('  </div>');
+                    return html.join(' ');
                 }
             }
         }
     ]).on('autocomplete:selected', function(event, suggestion) {
         window.location.href = suggestion.link;
     });
-})();
+})(jQuery);

--- a/resources/javascript/searchbar.js
+++ b/resources/javascript/searchbar.js
@@ -6,7 +6,7 @@
         '<div class="branding"><span>Powered by</span><a target="_blank" href="https://algolia.com"><img src="https://www.algolia.com/assets/algolia128x40.png"/></a></div>' +
         '</div>';
 
-    var client = algoliasearch('XT7HFL89G3', '9110ba06379a1615458dbce9604b1e2a');
+    var client = algoliasearch('BH4D9OD16A', '3403ae7bb4cb839fba71e2fae9ab1534');
     var index = client.initIndex('scaladocs');
     var ATTRIBUTES = ['content', 'h6', 'h5', 'h4', 'h3', 'h2', 'h1' ];
 

--- a/resources/javascript/searchbar.js
+++ b/resources/javascript/searchbar.js
@@ -1,0 +1,41 @@
+(function() {
+    var template =
+        '<div class="aa-dataset-a">' +
+        '</div>' +
+        '<div class="branding-footer">' +
+        '<div class="branding"><span>Powered by</span><a target="_blank" href="https://algolia.com"><img src="https://www.algolia.com/assets/algolia128x40.png"/></a></div>' +
+        '</div>';
+
+    var client = algoliasearch('XT7HFL89G3', '9110ba06379a1615458dbce9604b1e2a');
+    var index = client.initIndex('scaladocs');
+    var ATTRIBUTES = ['content', 'h6', 'h5', 'h4', 'h3', 'h2', 'h1' ];
+
+    var capitalize = function(string) {
+        return string.charAt(0).toUpperCase() + string.slice(1);
+    };
+
+    autocomplete('#q', {
+        hint: false,
+        debug: false,
+        templates: {
+            dropdownMenu: template
+        }
+    }, [
+        {
+            source: autocomplete.sources.hits(index, { hitsPerPage: 5, tagFilters: [ 'en' ], numericFilters: 'importance>0' }),
+            name: 'a',
+            displayKey: 'title',
+            templates: {
+                suggestion: function(suggestion) {
+                    for(var i = 0 ; i < ATTRIBUTES.length ; i++) {
+                        if(suggestion._highlightResult[ATTRIBUTES[i]] !== undefined) {
+                            return '<span class="title"><strong>' + capitalize(suggestion._tags[1]) + '</strong>: ' + suggestion._highlightResult.title.value + '</span><span class="text">' + suggestion._highlightResult[ATTRIBUTES[i]].value + '</span>';
+                        }
+                    }
+                }
+            }
+        }
+    ]).on('autocomplete:selected', function(event, suggestion) {
+        window.location.href = suggestion.link;
+    });
+})();

--- a/resources/stylesheets/base.css
+++ b/resources/stylesheets/base.css
@@ -73,7 +73,7 @@ input, textarea, select, .uneditable-input {
     border-bottom:1px solid #676767;
     -webkit-box-shadow:0 1px 0 rgba(255, 255, 255, 0.5);
     -moz-box-shadow:0 1px 0 rgba(255, 255, 255, 0.5);
-    box-shadow:0 1px 0 rgba(255, 255, 255, 0.5);	}
+    box-shadow:0 1px 0 rgba(255, 255, 255, 0.5);    }
 
 .footer ul li h5 a {
     font-size: 14px;
@@ -232,11 +232,11 @@ div#pop-up-arrow {
 }
 
 .algolia-autocomplete .aa-dropdown-menu {
-    width: 400px;
+    width: 500px;
     background-color: #fff;
     border: 1px solid #404040;
     margin-top: 2px;
-    margin-left: -219px;
+    margin-left: -319px;
     padding: 1px;
 }
 
@@ -254,14 +254,23 @@ div#pop-up-arrow {
     color: black;
 }
 
-.aa-suggestion span {
+.aa-suggestion .suggestion-category {
+    background-color: #DE3423;
+    font-weight: normal;
+    color: #fff;
+    padding: 5px;
+    font-size: 120%;
+    cursor: default;
+}
+
+.aa-suggestion .suggestion-content div {
     display: table-cell;
     padding: 5px 7px;
 }
 
-.aa-suggestion span:first-child {
+.aa-suggestion .suggestion-content div:first-child {
     border-right: 2px solid #DE3423;
-    width: 120px;
+    width: 180px;
 }
 
 .aa-dropdown-menu .branding-footer {

--- a/resources/stylesheets/base.css
+++ b/resources/stylesheets/base.css
@@ -1,168 +1,168 @@
-    html, body {
-		height: 100%;
-    }
+html, body {
+    height: 100%;
+}
 
-	.bottom {
-		min-height: 100%;
-		height: 100%;
-		padding-bottom: 20px;
-	}
+.bottom {
+    min-height: 100%;
+    height: 100%;
+    padding-bottom: 20px;
+}
 
-	/* every page should need this */
-	input, textarea, select, .uneditable-input {
-	       width: 165px;
-	}
+/* every page should need this */
+input, textarea, select, .uneditable-input {
+    width: 165px;
+}
 
-	* {
-		margin: 0;
-	}
+* {
+    margin: 0;
+}
 
-	.push {
-		height: 199px; /* .push must be the same height as .footer */
-		clear: both;
-	}
+.push {
+    height: 199px; /* .push must be the same height as .footer */
+    clear: both;
+}
 
-	.footer {
-		padding-top: 15px;
-		clear: both;
-	    background: #8d8d8d;
-		border-top: solid 1px #676767;
-		width: 100%;
-		color: rgba(255, 255, 255, 0.7);
-	    text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.5);
-	}
+.footer {
+    padding-top: 15px;
+    clear: both;
+    background: #8d8d8d;
+    border-top: solid 1px #676767;
+    width: 100%;
+    color: rgba(255, 255, 255, 0.7);
+    text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.5);
+}
 
-	.wrapper {
-		min-height: 100%;
-		height: auto !important;
-		height: 100%;
-		margin: 0 auto -199px; /* the bottom margin is the negative value of the footer's height */
-	}
+.wrapper {
+    min-height: 100%;
+    height: auto !important;
+    height: 100%;
+    margin: 0 auto -199px; /* the bottom margin is the negative value of the footer's height */
+}
 
-	.footer ul {
-	    float: left;
-	    margin: 0;
-	    padding: 10px 2% 20px 0;
-	    -webkit-box-sizing: content-box;
-	    -moz-box-sizing: content-box;
-	    box-sizing: content-box;
-	    width: 18%;
-	    list-style: none;
-	}
+.footer ul {
+    float: left;
+    margin: 0;
+    padding: 10px 2% 20px 0;
+    -webkit-box-sizing: content-box;
+    -moz-box-sizing: content-box;
+    box-sizing: content-box;
+    width: 18%;
+    list-style: none;
+}
 
-	.footer ul:last-child {
-	    padding-right: 0;
-	}
+.footer ul:last-child {
+    padding-right: 0;
+}
 
-	.footer ul li a {
-	    text-decoration: none;
-		color: rgba(255, 255, 255, 0.7);
-	    font-size: 12px;
-	}
+.footer ul li a {
+    text-decoration: none;
+    color: rgba(255, 255, 255, 0.7);
+    font-size: 12px;
+}
 
-	.footer ul li a:hover {
-	    text-decoration: underline;
-	}
+.footer ul li a:hover {
+    text-decoration: underline;
+}
 
-	.footer ul li h5 {
-		color: rgba(255, 255, 255, 0.9);
-	    text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.5);
-	    margin-bottom: 10px;
-	    padding-bottom: 10px;
-		line-height: 20px;
-		border-bottom:1px solid #676767;
-		-webkit-box-shadow:0 1px 0 rgba(255, 255, 255, 0.5);
-		-moz-box-shadow:0 1px 0 rgba(255, 255, 255, 0.5);
-		box-shadow:0 1px 0 rgba(255, 255, 255, 0.5);	}
+.footer ul li h5 {
+    color: rgba(255, 255, 255, 0.9);
+    text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.5);
+    margin-bottom: 10px;
+    padding-bottom: 10px;
+    line-height: 20px;
+    border-bottom:1px solid #676767;
+    -webkit-box-shadow:0 1px 0 rgba(255, 255, 255, 0.5);
+    -moz-box-shadow:0 1px 0 rgba(255, 255, 255, 0.5);
+    box-shadow:0 1px 0 rgba(255, 255, 255, 0.5);	}
 
-	.footer ul li h5 a {
-	    font-size: 14px;
-	    opacity: 1;
-	}
+.footer ul li h5 a {
+    font-size: 14px;
+    opacity: 1;
+}
 
-	.footer .copyright {
-	    font-size: 12px;
-		border-top:1px solid #808080;
-	    clear: both;
-	    padding: 10px 0 20px;
-	}
+.footer .copyright {
+    font-size: 12px;
+    border-top:1px solid #808080;
+    clear: both;
+    padding: 10px 0 20px;
+}
 
-	blockquote p {
-	    font-size: 13px;
-	    font-weight: normal;
-	    font-style: italic;
-	}
+blockquote p {
+    font-size: 13px;
+    font-weight: normal;
+    font-style: italic;
+}
 
-  .langbar li {
+.langbar li {
     display: inline;
-  }
+}
 
-  .langbar-cheatsheet li {
+.langbar-cheatsheet li {
     display: block;
-  }
+}
 
-  .langbar li a {
+.langbar li a {
     color: rgba(0, 0, 0, 0.5);
     font-weight: bold;
     text-decoration: none;
     font-size: 14px;
     margin-right: 5px;
-  }
+}
 
-  .langbar li a:hover {
+.langbar li a:hover {
     text-decoration: underline;
-  }
+}
 
 /*Coursera stuff*/
 
-  .label {
+.label {
     white-space: nowrap;
-  }
+}
 
-  h2 code { font-size: 18px; }
-  h3 code { font-size: 16px; }
+h2 code { font-size: 18px; }
+h3 code { font-size: 16px; }
 
-  .axis path,
+.axis path,
 .axis line {
-  fill: none;
-  stroke: #000;
-  shape-rendering: crispEdges;
+    fill: none;
+    stroke: #000;
+    shape-rendering: crispEdges;
 }
 
 .bar {
-  fill: steelblue;
+    fill: steelblue;
 }
 
 .x.axis path {
-  display: none;
+    display: none;
 }
 
 div#pop-up {
-  display: none;
-  position:absolute;
-  font-size: 11px;
-  text-align: center;
-  color: white;
-  background: rgba(0,0,0,0.5);
-  padding: 3px 8px;
-  -webkit-border-radius: 4px;
-     -moz-border-radius: 4px;
-          border-radius: 4px;
+    display: none;
+    position:absolute;
+    font-size: 11px;
+    text-align: center;
+    color: white;
+    background: rgba(0,0,0,0.5);
+    padding: 3px 8px;
+    -webkit-border-radius: 4px;
+    -moz-border-radius: 4px;
+    border-radius: 4px;
 
 }
 
 div#pop-up-arrow {
-  position: absolute;
-  width: 0;
-  height: 0;
-  border-color: transparent;
-  border-style: solid;
-  bottom: 0;
-  left: 50%;
-  margin-left: -5px;
-  margin-bottom: -5px;
-  border-top-color: rgba(0,0,0,0.5);
-  border-width: 5px 5px 0;
+    position: absolute;
+    width: 0;
+    height: 0;
+    border-color: transparent;
+    border-style: solid;
+    bottom: 0;
+    left: 50%;
+    margin-left: -5px;
+    margin-bottom: -5px;
+    border-top-color: rgba(0,0,0,0.5);
+    border-width: 5px 5px 0;
 }
 
 .jvectormap-label {
@@ -203,13 +203,87 @@ div#pop-up-arrow {
     top: 30px;
 }
 .h2 {
-  font-size: 24px;
-  line-height: 36px;
-  color: #404040;
-  font-weight: bold;
-  display: block;
-  -webkit-margin-before: 0.83em;
-  -webkit-margin-after: 0.83em;
-  -webkit-margin-start: 0px;
-  -webkit-margin-end: 0px;
+    font-size: 24px;
+    line-height: 36px;
+    color: #404040;
+    font-weight: bold;
+    display: block;
+    -webkit-margin-before: 0.83em;
+    -webkit-margin-after: 0.83em;
+    -webkit-margin-start: 0px;
+    -webkit-margin-end: 0px;
+}
+
+.topbar input:focus, .topbar input.focused {
+    background-color: #FEFEFE;
+    text-shadow: none;
+}
+
+.algolia-autocomplete {
+    width: 100%;
+}
+
+.algolia-autocomplete .aa-input, .algolia-autocomplete .aa-hint {
+    width: 100%;
+}
+
+.algolia-autocomplete .aa-hint {
+    color: #fff;
+}
+
+.algolia-autocomplete .aa-dropdown-menu {
+    width: 400px;
+    background-color: #fff;
+    border: 1px solid #404040;
+    margin-top: 2px;
+    margin-left: -219px;
+    padding: 1px;
+}
+
+.algolia-autocomplete .aa-dropdown-menu .aa-suggestion {
+    color: #696969;
+    cursor: pointer;
+}
+
+.algolia-autocomplete .aa-dropdown-menu .aa-suggestion.aa-cursor {
+    background-color: #B2D7FF;
+}
+.algolia-autocomplete .aa-dropdown-menu .aa-suggestion em {
+    font-weight: bold;
+    font-style: normal;
+    color: black;
+}
+
+.aa-suggestion span {
+    display: table-cell;
+    padding: 5px 7px;
+}
+
+.aa-suggestion span:first-child {
+    border-right: 2px solid #DE3423;
+    width: 120px;
+}
+
+.aa-dropdown-menu .branding-footer {
+    border-top: 1px #999 solid;
+}
+
+.aa-dropdown-menu .branding {
+    float: right;
+}
+
+.aa-dropdown-menu .branding a {
+    padding: 0;
+    display: inline;
+}
+
+.aa-dropdown-menu .branding img {
+    width: 50px;
+    margin: 5px;
+    vertical-align: middle;
+}
+
+.aa-dropdown-menu .branding span {
+    vertical-align: middle;
+    margin: 5px;
 }


### PR DESCRIPTION
Hello Scala team,

I've always wanted to be able to easily search inside the Scaladocs, so I've added this feature.

![Desktop GIF](http://g.recordit.co/433NLw7XKe.gif)

You can see it live and test it here: https://scaladocs.algolia.com/.

This pull request uses Algolia API to index and search the documentation. 

It *does not* includes the indexing part, it is done with a internal tool. We have a [Jekyll plugin](https://github.com/algolia/algoliasearch-jekyll), which handles indexing & searching but it is only compatible with version `>2.5`, and we could have a better autocomplete, with more context (as seen [here](http://bootstrap.algolia.com/)).

I was not sure if you wanted to upgrade your Jekyll. But if you prefer I can update the Jekyll version and add the search. 

## Benefits for the end user

* Search in the whole documentation, with typo-tolerance
* Fast results (your search index is replicated in 13 regions worldwide, it is fast no matter where the user is)
* Instant access to the documentation at the first keystroke, in a few milliseconds
* Directly scroll to the relevant part of the page

## How it works

We've created a free account for you that hosts the documentation. When a user does a search, it uses the Algolia API to retrieve the most relevant results from the documentation and display them in a dropdown.

## Testing the pull request locally

If you want to test the PR locally, you can just launch Jekyll.

## Updating the index

As it uses our internal tool, it will be update once in a day.

But if you prefered the Jekyll plugins, it adds a new command: `jekyll algolia push`. This will read the generated HTML files from a jekyll build, extract text & headers and index them in Algolia. You'll basically have to re-run this command everytime you push a new version to gh-pages. See [plugin doc](https://github.com/algolia/algoliasearch-jekyll#algolia-jekyll-plugin)

## About Algolia

At Algolia we provide a hosted search API and support community websites like Hackernews search, CDNJS, GrowthHackers, Product Hunt or the Laravel documentation with free plans. 

If you want to move forward with this implementation, I'll send you the free and unlimited credentials to your Algolia dashboard.

I'm available for any questions you may have or any more information you would need.