### PR TITLE
Shrank range in fold/sum example to correct overflow error.

### DIFF
--- a/overviews/parallel-collections/overview.md
+++ b/overviews/parallel-collections/overview.md
@@ -95,11 +95,11 @@ Using a parallel `map` to transform a collection of `String` to all-uppercase:
 
 Summing via `fold` on a `ParArray`:
 
-    scala> val parArray = (1 to 1000000).toArray.par    
+    scala> val parArray = (1 to 10000).toArray.par    
     parArray: scala.collection.parallel.mutable.ParArray[Int] = ParArray(1, 2, 3, ...
     
     scala> parArray.fold(0)(_ + _)
-    res0: Int = 1784293664
+    res0: Int = 50005000
 
 #### filter
 


### PR DESCRIPTION
Proposed fix for issue #480