### PR TITLE
Fix extension methods example in the ja documentation

### DIFF
--- a/ja/overviews/core/value-classes.md
+++ b/ja/overviews/core/value-classes.md
@@ -47,7 +47,7 @@ title: 値クラスと汎用トレイト
 
 `RichInt` から抜粋した以下のコードは、それが `Int` を拡張して `3.toHexString` という式が書けるようにしていることを示す:
 
-    class RichInt(val self: Int) extends AnyVal {
+    implicit class RichInt(val self: Int) extends AnyVal {
       def toHexString: String = java.lang.Integer.toHexString(self)
     }
 

--- a/zh-cn/overviews/core/value-classes.md
+++ b/zh-cn/overviews/core/value-classes.md
@@ -40,7 +40,7 @@ Value class只能继承universal traits，但其自身不能再被继承。所�
 
 下面有关RichInt的代码片段示范了RichInt是如何继承Int来允许3.toHexString的表达式：
 
-    class RichInt(val self: Int) extends AnyVal {
+    implicit class RichInt(val self: Int) extends AnyVal {
       def toHexString: String = java.lang.Integer.toHexString(self)
     }
     


### PR DESCRIPTION
I fixed an issue that did not exist a `implicit` keyword in the "Extension methods" example of the ja documentation.