### PR TITLE
Fixed tiny typo

### DIFF
--- a/overviews/core/_posts/2012-09-20-futures.md
+++ b/overviews/core/_posts/2012-09-20-futures.md
@@ -312,7 +312,7 @@ some throwable object.
 Where an `Option[T]` could either be a value (i.e. `Some[T]`) or no value 
 at all (i.e. `None`), `Try[T]` is a `Success[T]` when it holds a value
 and otherwise `Failure[T]`, which holds an exception. `Failure[T]` holds
-more information that just a plain `None` by saying why the value is not
+more information than just a plain `None` by saying why the value is not
 there.
 In the same time, you can think of `Try[T]` as a special version
 of `Either[Throwable, T]`, specialized for the case when the left


### PR DESCRIPTION
Changed

    holds more information that just a plain `None` by saying why the value is not there.

to

    holds more information than just a plain `None` by saying why the value is not there.
    --------------------------^
