### PR TITLE
Fixed small typo

### DIFF
--- a/tutorials/tour/local-type-inference.md
+++ b/tutorials/tour/local-type-inference.md
@@ -9,7 +9,7 @@ num: 28
 tutorial-next: operators
 tutorial-previous: polymorphic-methods
 ---
-Scala has a built-in type inference mechanism which allows the programmer to omit certain type annotations. It is, for instance, often not necessary in Scala to specify the type of a variable, since the compiler can deduce the type from the initialization expression of the variable. Also return types of methods can often be omitted since they corresponds to the type of the body, which gets inferred by the compiler.
+Scala has a built-in type inference mechanism which allows the programmer to omit certain type annotations. It is, for instance, often not necessary in Scala to specify the type of a variable, since the compiler can deduce the type from the initialization expression of the variable. Also return types of methods can often be omitted since they correspond to the type of the body, which gets inferred by the compiler.
 
 Here is an example:
 


### PR DESCRIPTION
I think "...since they correspond to the type of the body..." sounds correct, rather than "...since they corresponds to the type of the body"