### PR TITLE
Fixed wording comment spacing

### DIFF
--- a/overviews/collections/overview.md
+++ b/overviews/collections/overview.md
@@ -86,7 +86,7 @@ can be accessed alternatively as
 
     scala.collection.immutable.List   // that's where it is defined
     scala.List                        // via the alias in the scala package
-    List                              // because  scala._
+    List                              // because scala._
                                       // is always automatically imported
 
 Other types aliased are

--- a/overviews/collections/overview.md
+++ b/overviews/collections/overview.md
@@ -85,11 +85,11 @@ names without needing an import. An example is the `List` type, which
 can be accessed alternatively as
 
     scala.collection.immutable.List   // that's where it is defined
-    scala.List                        // via the alias in the  scala package
+    scala.List                        // via the alias in the scala package
     List                              // because  scala._
                                       // is always automatically imported
 
-Other types so aliased are
+Other types aliased are
 [Traversable](http://www.scala-lang.org/api/current/scala/collection/Traversable.html), [Iterable](http://www.scala-lang.org/api/current/scala/collection/Iterable.html), [Seq](http://www.scala-lang.org/api/current/scala/collection/Seq.html), [IndexedSeq](http://www.scala-lang.org/api/current/scala/collection/IndexedSeq.html), [Iterator](http://www.scala-lang.org/api/current/scala/collection/Iterator.html), [Stream](http://www.scala-lang.org/api/current/scala/collection/immutable/Stream.html), [Vector](http://www.scala-lang.org/api/current/scala/collection/immutable/Vector.html), [StringBuilder](http://www.scala-lang.org/api/current/scala/collection/mutable/StringBuilder.html), and [Range](http://www.scala-lang.org/api/current/scala/collection/immutable/Range.html).
 
 The following figure shows all collections in package


### PR DESCRIPTION
Fixed comment spacing so it doesn't create a new line and changed the wording of "Other types so aliased are..." to "Other types aliased are...".