### PR TITLE
Fix HTML redirects on scaladoc pages

### DIFF
--- a/_layouts/redirected.html
+++ b/_layouts/redirected.html
@@ -1,0 +1,16 @@
+---
+layout: default
+---
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="canonical" href="{{ page.redirect_to }}"/>
+<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<meta http-equiv="refresh" content="0;url={{ page.redirect_to }}" />
+</head>
+<body>
+    <h1>Redirecting...</h1>
+      <a href="{{ page.redirect_to }}">Click here if you are not redirected.<a>
+      <script>location='{{ page.redirect_to }}'</script>
+</body>
+</html>

--- a/overviews/scaladoc/basics.md
+++ b/overviews/scaladoc/basics.md
@@ -1,10 +1,6 @@
-<html>
-<head>
-<meta http-equiv="Refresh" content="0; url=http://docs.scala-lang.org/overviews/scaladoc/for-library-authors.html" />
-<title>Moved</title>
-</head>
-<body>
-<h1>Moved</h1>
-<p>This page has moved to <a href="http://docs.scala-lang.org/overviews/scaladoc/for-library-authors.html">http://docs.scala-lang.org/overviews/scaladoc/for-library-authors.html</a>.</p>
-</body>
-</html>
+---
+layout: redirected
+sitemap: false
+permalink: /overviews/scaladoc/basics.html
+redirect_to: /overviews/scaladoc/for-library-authors.html
+---

--- a/overviews/scaladoc/usage.md
+++ b/overviews/scaladoc/usage.md
@@ -1,10 +1,6 @@
-<html>
-<head>
-<meta http-equiv="Refresh" content="0; url=http://docs.scala-lang.org/overviews/scaladoc/interface.html" />
-<title>Moved</title>
-</head>
-<body>
-<h1>Moved</h1>
-<p>This page has moved to <a href="http://docs.scala-lang.org/overviews/scaladoc/interface.html">http://docs.scala-lang.org/overviews/scaladoc/interface.html</a>.</p>
-</body>
-</html>
+---
+layout: redirected
+sitemap: false
+permalink: /overviews/scaladoc/usage.html
+redirect_to: /overviews/scaladoc/interface.html
+---


### PR DESCRIPTION
These two redirects are broken:

- http://docs.scala-lang.org/overviews/scaladoc/basics.html
- http://docs.scala-lang.org/overviews/scaladoc/usage.html

Add new layout, "redirected", based on blog post by Kanishk Kunal at
<https://superdevresources.com/redirects-jekyll-github-pages/>.

- `_layouts/redirected.html`

Convert two HTML-based redirects to use new layout for redirects:

- `overviews/scaladoc/basics.md`
- `overviews/scaladoc/usage.md`