### PR TITLE
correct the method name for creating Future

### DIFF
--- a/overviews/core/_posts/2012-09-20-futures.md
+++ b/overviews/core/_posts/2012-09-20-futures.md
@@ -200,13 +200,13 @@ once.
 Once a `Future` object is given a value or an exception, it becomes
 in effect immutable-- it can never be overwritten.
 
-The simplest way to create a future object is to invoke the `future`
+The simplest way to create a future object is to invoke the `Future`
 method which starts an asynchronous computation and returns a
 future holding the result of that computation.
 The result becomes available once the future completes.
 
 Note that `Future[T]` is a type which denotes future objects, whereas
-`future` is a method which creates and schedules an asynchronous
+`Future` is a method which creates and schedules an asynchronous
 computation, and then returns a future object which will be completed
 with the result of that computation.
 
@@ -237,7 +237,7 @@ has to be sent over a network, which can take a long time.
 This is illustrated with the call to the method `getFriends` that returns `List[Friend]`.
 To better utilize the CPU until the response arrives, we should not
 block the rest of the program-- this computation should be scheduled
-asynchronously. The `future` method does exactly that-- it performs
+asynchronously. The `Future` method does exactly that-- it performs
 the specified computation block concurrently, in this case sending
 a request to the server and waiting for a response.
 
@@ -246,7 +246,7 @@ responds.
 
 An unsuccessful attempt may result in an exception. In
 the following example, the `session` value is incorrectly
-initialized, so the computation in the `future` block will throw a `NullPointerException`.
+initialized, so the computation in the `Future` block will throw a `NullPointerException`.
 This future `f` is then failed with this exception instead of being completed successfully:
 	
     val session = null
@@ -258,9 +258,9 @@ The line `import ExecutionContext.Implicits.global` above imports
 the default global execution context.
 Execution contexts execute tasks submitted to them, and
 you can think of execution contexts as thread pools.
-They are essential for the `future` method because
+They are essential for the `Future` method because
 they handle how and when the asynchronous computation is executed.
-You can define your own execution contexts and use them with `future`,
+You can define your own execution contexts and use them with `Future`,
 but for now it is sufficient to know that
 you can import the default execution context as shown above.
 
@@ -749,7 +749,7 @@ the throwable types it matches.
 -->
 
 <!--
-Invoking the `future` construct uses a global execution context to start an asynchronous computation. In the case the client desires to use a custom execution context to start an asynchronous computation:
+Invoking the `Future` construct uses a global execution context to start an asynchronous computation. In the case the client desires to use a custom execution context to start an asynchronous computation:
 
     val f = customExecutionContext Future {
       4 / 2


### PR DESCRIPTION
The Future is constructed using `Future`, but name was written as
`future` by mistake.