### PR TITLE
Add minor correction to the SIP process

### DIFF
--- a/sips/sip-submission.md
+++ b/sips/sip-submission.md
@@ -133,7 +133,9 @@ design document, progress with the implementation, etc) to the SIP Committee.
 Based on the feedback, the SIP is either:
 
 1. Accepted, in which case the committee will propose a release date to the
-   compiler maintainers, where the role of the committee ends.
+   compiler maintainers, where the role of the committee ends. In certain cases,
+   accepted proposal may need exceptional follow-up iterations to flesh out all
+   the details of the proposed specification or implementation.
 2. Rejected, in which case the SIP is closed and no longer evaluated in the
    future.
 3. Under revision, in which case the author needs to continue the formal


### PR DESCRIPTION
Account for the fact that accepted proposals may need exceptional
follow-up iterations to flesh out all the details of the proposed
specification or implementation.