### PR TITLE
Final improvement in `accepted` clause

### DIFF
--- a/sips/sip-submission.md
+++ b/sips/sip-submission.md
@@ -132,10 +132,8 @@ During every iteration, the appointed reviewer presents the changes (updated
 design document, progress with the implementation, etc) to the SIP Committee.
 Based on the feedback, the SIP is either:
 
-1. Accepted, in which case the committee proposes a target Scala version to the
-   compiler maintainers, where the role of the committee ends. The Committee
-   asks authors to update both the specification and implementation according to
-   the final verdict.
+1. Accepted, in which case the committee proposes that the compiler maintainers
+   include the new language feature in a future release of the Scala compiler.   
 2. Rejected, in which case the SIP is closed and no longer evaluated in the
    future.
 3. Under revision, in which case the author needs to continue the formal


### PR DESCRIPTION
After some thought, I believe that the compiler maintainers have a
better judgement of when proposals can be merged, especially because of
the compatibility guarantees that the Scala compiler contract enforces.

In this way, I propose that the Compiler team chooses the most
appropriate version to include the accepted proposal.