### PR TITLE
Correct return type for Iterator in lazyMap example of Views section

### DIFF
--- a/ja/overviews/collections/views.md
+++ b/ja/overviews/collections/views.md
@@ -16,7 +16,7 @@ language: ja
 
 非正格な変換演算子の具体例として、以下の遅延 map 演算の実装を見てほしい:
 
-    def lazyMap[T, U](coll: Iterable[T], f: T => U) = new Iterable[T] {
+    def lazyMap[T, U](coll: Iterable[T], f: T => U) = new Iterable[U] {
       def iterator = coll.iterator map f
     }
 

--- a/overviews/collections/views.md
+++ b/overviews/collections/views.md
@@ -15,7 +15,7 @@ There are two principal ways to implement transformers. One is _strict_, that is
 
 As an example of a non-strict transformer consider the following implementation of a lazy map operation:
 
-    def lazyMap[T, U](coll: Iterable[T], f: T => U) = new Iterable[T] {
+    def lazyMap[T, U](coll: Iterable[T], f: T => U) = new Iterable[U] {
       def iterator = coll.iterator map f
     }
 

--- a/zh-cn/overviews/collections/views.md
+++ b/zh-cn/overviews/collections/views.md
@@ -15,7 +15,7 @@ language: zh-cn
 
 作为一个松弛法转换器的例子，分析下面的 lazy map操作：
 
-    def lazyMap[T, U](coll: Iterable[T], f: T => U) = new Iterable[T] {
+    def lazyMap[T, U](coll: Iterable[T], f: T => U) = new Iterable[U] {
       def iterator = coll.iterator map f
     }
 


### PR DESCRIPTION
The function in the example maps a function T => U on the given Iterable
of type T, and should return an Iterable of type U.

---

This was mentioned in one of the comments over at http://docs.scala-lang.org/overviews/collections/views.html. I figured I'd make a pull request since I too stalled on this example.