### PR TITLE
Revert .travis.yml back to sudo: false w/ workaround

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
-sudo: true
+# opt-in to TravisCI's faster container-based infrastructure
+sudo: false
 
 language: ruby
 rvm: 2.0.0
@@ -7,8 +8,10 @@ rvm: 2.0.0
 # will kick in and use `vendor`, ignoring our BUNDLE_PATH
 # declaration in `.bundle/config`
 install:
-- ./scripts/install-coursier.sh
+- curl -L -o coursier https://git.io/vgvpD
 - bundle install
+
+before_script: chmod +x coursier
 
 script:
 - ./scripts/run-tut.sh

--- a/scripts/install-coursier.sh
+++ b/scripts/install-coursier.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-curl -L -o coursier https://git.io/vgvpD
-chmod +x coursier


### PR DESCRIPTION
For some reason calling chmod this way TravisCI is fine with.

This way the build is back to using the faster container-based infrastructure.