### PR TITLE
Upgraded project docs to include incremental switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,29 +19,15 @@ This site uses a Jekyll, a Ruby framework. You'll need Ruby and Bundler installe
 
 cd into the directory where you cloned this repository, then install the required gems with `bundle install`. This will automatically put the gems into `./vendor/bundle`.
 
-Start the server in the context of the bundle:
+Start the server in the context of the bundle (use `-I` for incremental builds):
 
-    bundle exec jekyll serve
+    bundle exec jekyll serve -I
+
+`It might take around 5 minutes at first but incremental compilations will be fast.`
 
 The generated site is available at `http://localhost:4000`
 
-If you add `--watch` at the end of the command line above, Jekyll will automatically watch for changes on the filesystem, and regenerate the site. It can take a few minutes for your changes to appear. Watch Jekyll's output. When you start up you'll see this:
-
-     $ bundle exec jekyll serve --watch
-     Configuration file: /Users/ben/src/scala.github.com/_config.yml
-                 Source: /Users/ben/src/scala.github.com
-            Destination: /Users/ben/src/scala.github.com/_site
-          Generating...
-                     done.
-    Auto-regeneration: enabled for '/Users/ben/src/scala.github.com'
-
-When you change a file, this output will tell you that jekyll is regenerating. It's not done until it says `done.`
-
-    Server running... press ctrl-c to stop.
-      Regenerating: 1 files at 2014-11-29 09:19:04 ...done.
-      Regenerating: 3 files at 2014-11-29 09:21:39 ...done.
-      Regenerating: 2 files at 2014-11-29 09:25:10 ...done.
-      Regenerating: 2 files at 2014-11-29 09:27:49
+If you add `--watch` at the end of the command line above, Jekyll will automatically watch for changes on the filesystem, and regenerate the site.
 
 If you get `incompatible encoding` errors when generating the site under Windows, then ensure that the
 console in which you are running jekyll can work with UTF-8 characters. As described in the blog
@@ -61,4 +47,3 @@ There's a free markdown editor for OSX called [Mou](http://25.io/mou/). It's qui
 ## License ##
 
 All documentation contained in this repository is licensed by EPFL under a Creative Commons Attribution-Share Alike 3.0 Unported license ("CC-BY-SA"), unless otherwise noted. By submitting a "pull request," or otherwise contributing to this repository, you implicitly agree to license your contribution under the above CC-BY-SA license. The source code of this website is licensed to EPFL under the [Scala License](http://www.scala-lang.org/node/146), unless otherwise noted.
-


### PR DESCRIPTION
After discussion with @SethTisue (here: https://github.com/scala/scala-lang/issues/493 ) about compilation speed I have upgraded `jekyll` to `3.3.0` 
and upgraded docs to include `-I` incremental compilation flag. 

At first it took ~5 minutes on my machine to build the whole thing but after that only few seconds: 
```
Incremental build: enabled
      Generating...
                    done in 2.065 seconds.
```

Hope it helps with further updates. 

Here's the list of used gems:

```
➜  scala.github.com git:(feat/jekyll_incremental_upgrade) bundle show
Gems included by the bundle:
  * addressable (2.4.0)
  * bundler (1.13.5)
  * colorator (1.1.0)
  * ffi (1.9.14)
  * forwardable-extended (2.6.0)
  * jekyll (3.3.0)
  * jekyll-redirect-from (0.11.0)
  * jekyll-sass-converter (1.4.0)
  * jekyll-watch (1.5.0)
  * kramdown (1.12.0)
  * liquid (3.0.6)
  * listen (3.0.8)
  * mercenary (0.3.6)
  * pathutil (0.14.0)
  * rb-fsevent (0.9.7)
  * rb-inotify (0.9.7)
  * rouge (1.11.1)
  * safe_yaml (1.0.4)
  * sass (3.4.22)
```

For more speed improvements we would probably need to move to hugo or some other static generator.