### PR TITLE
avoid postfix syntax in operator tour

### DIFF
--- a/tutorials/tour/operators.md
+++ b/tutorials/tour/operators.md
@@ -10,28 +10,28 @@ tutorial-next: automatic-closures
 tutorial-previous: local-type-inference
 ---
 
-Any method which takes a single parameter can be used as an *infix operator* in Scala. Here is the definition of class `MyBool` which defines three methods `and`, `or`, and `negate`.
+Any method which takes a single parameter can be used as an *infix operator* in Scala. Here is the definition of class `MyBool` which includes methods `and` and `or`:
 
 ```tut
-class MyBool(x: Boolean) {
+case class MyBool(x: Boolean) {
   def and(that: MyBool): MyBool = if (x) that else this
   def or(that: MyBool): MyBool = if (x) this else that
-  def negate: MyBool = new MyBool(!x)
+  def negate: MyBool = MyBool(!x)
 }
 ```
 
 It is now possible to use `and` and `or` as infix operators:
 
 ```tut
-def not(x: MyBool) = x negate; // semicolon required here
+def not(x: MyBool) = x.negate
 def xor(x: MyBool, y: MyBool) = (x or y) and not(x and y)
 ```
 
-As the first line of this code shows, it is also possible to use nullary methods as postfix operators. The second line defines an `xor` function using the `and` and `or` methods as well as the new `not` function. In this example the use of _infix operators_ helps to make the definition of `xor` more readable.
+This helps to make the definition of `xor` more readable.
 
 Here is the corresponding code in a more traditional object-oriented programming language syntax:
 
 ```tut
-def not(x: MyBool) = x.negate; // semicolon required here
+def not(x: MyBool) = x.negate
 def xor(x: MyBool, y: MyBool) = x.or(y).and(x.and(y).negate)
 ```


### PR DESCRIPTION
since it's no longer a recommended part of the language

reported by Sebastian Nickel at
http://docs.scala-lang.org/tutorials/tour/operators.html#comment-2954987627