### PR TITLE
add missing println statements to case-classes.md

### DIFF
--- a/tutorials/tour/case-classes.md
+++ b/tutorials/tour/case-classes.md
@@ -120,6 +120,11 @@ val someVoiceRecording = VoiceRecording("Tom", "voicerecording.org/id/123")
 val specialEmail = Email("jane@mail.com", "Drinks tonight?", "I'm free after 5!")
 val specialSms = SMS("55555", "I'm here! Where are you?")
 
+println(showNotificationSpecial(someSms, SPECIAL_EMAIL, SPECIAL_NUMBER))
+println(showNotificationSpecial(someVoiceRecording, SPECIAL_EMAIL, SPECIAL_NUMBER))
+println(showNotificationSpecial(specialEmail, SPECIAL_EMAIL, SPECIAL_NUMBER))
+println(showNotificationSpecial(specialSms, SPECIAL_EMAIL, SPECIAL_NUMBER))
+
 // prints: 
 // You got an SMS from 12345! Message: Are you there?
 // you received a Voice Recording from Tom! Click the link to hear it: voicerecording.org/id/123


### PR DESCRIPTION
The last example in the case-classes.md file shows what the example
output will be but the program snippet does not show any println
statements with the usage of the newly introduced case class function.
This change adds the println calls that use the new function and match
the output.