### PR TITLE
Enabled pt-br lang for Scala Tour

### DIFF
--- a/tutorials/tour/abstract-types.md
+++ b/tutorials/tour/abstract-types.md
@@ -6,7 +6,6 @@ disqus: true
 
 tutorial: scala-tour
 num: 22
-languages: [ba, es, ko]
 next-page: compound-types
 previous-page: inner-classes
 ---

--- a/tutorials/tour/tour-of-scala.md
+++ b/tutorials/tour/tour-of-scala.md
@@ -6,6 +6,7 @@ disqus: true
 
 tutorial: scala-tour
 num: 1
+languages: [ba, es, ko, pt-br]
 outof: 33
 next-page: unified-types
 ---


### PR DESCRIPTION
- Added the pt-br in the languages list 
- Moved the lang list from `abstract-types.md` to `tour-of-scala.md`

@heathermiller I put the lang list in the first page of Scala Tour tutorial. I believe it is easier to update there (for future translations). What do you think? 