### PR TITLE
Make unified-types.md more intuitive to new comers

### DIFF
--- a/tutorials/tour/unified-types.md
+++ b/tutorials/tour/unified-types.md
@@ -36,7 +36,7 @@ val list: List[Any] = List(
 list.foreach(element => println(element))
 ````
 
-The application defines a variable `list` of type `List[Any]`. The list is initialized with elements of various types, but they all are instance of `scala.Any`, so you can add them to the list.
+It defines a variable `list` of type `List[Any]`. The list is initialized with elements of various types, but they all are instance of `scala.Any`, so you can add them to the list.
 
 Here is the output of the program:
 

--- a/tutorials/tour/unified-types.md
+++ b/tutorials/tour/unified-types.md
@@ -47,5 +47,5 @@ a string
 732
 c
 true
-$line15.$read$$iw$$iw$$$Lambda$1095/599060649@108a7fff
+<function>
 ```

--- a/tutorials/tour/unified-types.md
+++ b/tutorials/tour/unified-types.md
@@ -38,7 +38,9 @@ object UnifiedTypes extends App {
 }
 ```
 
-The application defines a variable `list` of type `List[Any]`. The list is initialized with elements of various types, but they all are instance of `scala.Any`. In the end, the application outputs something like below:
+The program declares an application `UnifiedTypes` in form of a top-level [singleton object](singleton-objects.html) extending [`App`](http://www.scala-lang.org/api/2.12.x/scala/App.html) so that the body of it acts as a main function.
+
+The application defines a variable `list` of type `List[Any]`. The list is initialized with elements of various types, and they all are instance of `scala.Any`. In the end, the application outputs something like below:
 
 ```tut
 a string

--- a/tutorials/tour/unified-types.md
+++ b/tutorials/tour/unified-types.md
@@ -26,13 +26,13 @@ Here is an example that demonstrates that numbers, characters, boolean values, a
 
 ```tut
 object UnifiedTypes extends App {
-  var list: List[Any] = List()
-
-  list = list :+ "This is a string"
-  list = list :+ 732
-  list = list :+ 'c'
-  list = list :+ true
-  list = list :+ (() => "This is an anonymous function returning a string")
+  val list: List[Any] = List(
+    "This is a string",
+    732,
+    'c',
+    true,
+    () => "This is an anonymous function returning a string"
+  )
 
   list.foreach(element => println(element))
 }

--- a/tutorials/tour/unified-types.md
+++ b/tutorials/tour/unified-types.md
@@ -10,7 +10,7 @@ next-page: classes
 previous-page: tour-of-scala
 ---
 
-In contrast to Java, all values in Scala are objects (including numerical values and functions). Since Scala is class-based, all values are instances of a class. The diagram below illustrates the class hierarchy.
+In Scala, all values are instance of a class, including numerical values and functions. The diagram below illustrates the class hierarchy.
 
 ![Scala Type Hierarchy]({{ site.baseurl }}/resources/images/classhierarchy.img_assist_custom.png)
 

--- a/tutorials/tour/unified-types.md
+++ b/tutorials/tour/unified-types.md
@@ -38,7 +38,7 @@ object UnifiedTypes extends App {
 }
 ```
 
-The program defines a variable `list` which refers to an instance of class `List[Any]`. The program adds elements of various types to this list. In the end, the program outputs something like below:
+The application defines a variable `list` which refers to an instance of class `List[Any]`. The list is initialized with elements of various types. In the end, the application outputs something like below:
 
 ```tut
 This is a string

--- a/tutorials/tour/unified-types.md
+++ b/tutorials/tour/unified-types.md
@@ -25,31 +25,22 @@ The superclass of all classes `scala.Any` has two direct subclasses: `scala.AnyV
 Here is an example that demonstrates that numbers, characters, boolean values, and functions are all objects just like every other object:
 
 ```tut
-scala> var list: List[Any] = List()
-list: List[Any] = List()
+object UnifiedTypes extends App {
+  var list: List[Any] = List()
 
-scala> list = list :+ "This is a string"
-list: List[Any] = List(This is a string)
+  list = list :+ "This is a string"
+  list = list :+ 732
+  list = list :+ 'c'
+  list = list :+ true
+  list = list :+ (() => "This is an anonymous function returning a string")
 
-scala> list = list :+ 732
-list: List[Any] = List(This is a string, 732)
-
-scala> list = list :+ 'c'
-list: List[Any] = List(This is a string, 732, c)
-
-scala> list = list :+ true
-list: List[Any] = List(This is a string, 732, c, true)
-
-scala> list = list :+ (() => "This is an anonymous function returning a string")
-list: List[Any] = List(This is a string, 732, c, true, $$Lambda$1095/599060649@108a7fff)
+  list.foreach(element => println(element))
+}
 ```
 
-The program defines a variable `list` which refers to an instance of class `List[Any]`. The program adds elements of various types to this list.
-
-When you print each element, it will output something like the following:
+The program defines a variable `list` which refers to an instance of class `List[Any]`. The program adds elements of various types to this list. In the end, the program outputs something like below:
 
 ```tut
-scala> list.foreach(element => println(element))
 This is a string
 732
 c

--- a/tutorials/tour/unified-types.md
+++ b/tutorials/tour/unified-types.md
@@ -22,16 +22,16 @@ The superclass of all classes `scala.Any` has two direct subclasses: `scala.AnyV
 
 `scala.AnyRef` represents reference classes. All non-value classes are defined as reference class. Every user-defined class in Scala implicitly extends `scala.AnyRef`. If Scala is used in the context of a Java runtime environment, then `scala.AnyRef` corresponds to `java.lang.Object`.
 
-Here is an example that demonstrates that numbers, characters, boolean values, and functions are all objects just like every other object:
+Here is an example that demonstrates that strings, integers, characters, boolean values, and functions are all objects just like every other object:
 
 ```tut
 object UnifiedTypes extends App {
   val list: List[Any] = List(
-    "This is a string",
-    732,
-    'c',
-    true,
-    () => "This is an anonymous function returning a string"
+    "a string",
+    732,  // an integer
+    'c',  // a character
+    true, // a boolean value
+    () => "an anonymous function returning a string"
   )
 
   list.foreach(element => println(element))

--- a/tutorials/tour/unified-types.md
+++ b/tutorials/tour/unified-types.md
@@ -42,7 +42,7 @@ The program declares an application `UnifiedTypes` in form of a top-level [singl
 
 The application defines a variable `list` of type `List[Any]`. The list is initialized with elements of various types, but they all are instance of `scala.Any`, so you can add them to the list.
 
-In the end, the application outputs something like below:
+Here is the output of the program:
 
 ```tut
 a string

--- a/tutorials/tour/unified-types.md
+++ b/tutorials/tour/unified-types.md
@@ -20,7 +20,7 @@ The superclass of all classes `scala.Any` has two direct subclasses: `scala.AnyV
 
 `scala.AnyVal` represents value classes. All value classes are not nullable and predefined; they correspond to the primitive types of Java-like languages. Note that the diagram above also shows implicit conversions between the value classes.
 
-`scala.AnyRef` represents reference classes. All non-value classes are defined as reference class. Every user-defined class in Scala implicitly extends `scala.AnyRef`. If Scala is used in the context of a Java runtime environment, then `scala.AnyRef` corresponds to `java.lang.Object`.
+`scala.AnyRef` represents reference classes. All non-value classes are defined as reference class. Every user-defined class in Scala implicitly extends `scala.AnyRef`. If Scala is used in the context of a Java runtime environment, `scala.AnyRef` corresponds to `java.lang.Object`.
 
 Here is an example that demonstrates that strings, integers, characters, boolean values, and functions are all objects just like every other object:
 

--- a/tutorials/tour/unified-types.md
+++ b/tutorials/tour/unified-types.md
@@ -18,7 +18,7 @@ In contrast to Java, all values in Scala are objects (including numerical values
 
 The superclass of all classes `scala.Any` has two direct subclasses: `scala.AnyVal` and `scala.AnyRef`.
 
-`scala.AnyVal` represents value classes. All value classes are predefined; they correspond to the primitive types of Java-like languages. Note that the diagram above also shows implicit conversions between the value classes.
+`scala.AnyVal` represents value classes. All value classes are not nullable and predefined; they correspond to the primitive types of Java-like languages. Note that the diagram above also shows implicit conversions between the value classes.
 
 `scala.AnyRef` represents reference classes. All non-value classes are defined as reference class. Every user-defined class in Scala implicitly extends `scala.AnyRef`. If Scala is used in the context of a Java runtime environment, then `scala.AnyRef` corresponds to `java.lang.Object`.
 
@@ -38,7 +38,7 @@ object UnifiedTypes extends App {
 }
 ```
 
-The application defines a variable `list` which refers to an instance of class `List[Any]`. The list is initialized with elements of various types. In the end, the application outputs something like below:
+The application defines a variable `list` of type `List[Any]`. The list is initialized with elements of various types, but they all are instance of `scala.Any`. In the end, the application outputs something like below:
 
 ```tut
 a string

--- a/tutorials/tour/unified-types.md
+++ b/tutorials/tour/unified-types.md
@@ -16,33 +16,43 @@ In contrast to Java, all values in Scala are objects (including numerical values
 
 ## Scala Class Hierarchy ##
 
-The superclass of all classes `scala.Any` has two direct subclasses `scala.AnyVal` and `scala.AnyRef` representing two different class worlds: value classes and reference classes. All value classes are predefined; they correspond to the primitive types of Java-like languages. All other classes define reference types. User-defined classes define reference types by default; i.e. they always (indirectly) subclass `scala.AnyRef`. Every user-defined class in Scala implicitly extends the trait `scala.ScalaObject`. Classes from the infrastructure on which Scala is running (e.g. the Java runtime environment) do not extend `scala.ScalaObject`. If Scala is used in the context of a Java runtime environment, then `scala.AnyRef` corresponds to `java.lang.Object`.
-Please note that the diagram above also shows implicit conversions between the value classes.
-Here is an example that demonstrates that both numbers, characters, boolean values, and functions are objects just like every other object:
- 
+The superclass of all classes `scala.Any` has two direct subclasses: `scala.AnyVal` and `scala.AnyRef`.
+
+`scala.AnyVal` represents value classes. All value classes are predefined; they correspond to the primitive types of Java-like languages. Note that the diagram above also shows implicit conversions between the value classes.
+
+`scala.AnyRef` represents reference classes. All non-value classes are defined as reference class. Every user-defined class in Scala implicitly extends `scala.AnyRef`. If Scala is used in the context of a Java runtime environment, then `scala.AnyRef` corresponds to `java.lang.Object`.
+
+Here is an example that demonstrates that numbers, characters, boolean values, and functions are all objects just like every other object:
+
 ```tut
-object UnifiedTypes extends App {
-  val set = new scala.collection.mutable.LinkedHashSet[Any]
-  set += "This is a string"  // add a string
-  set += 732                 // add a number
-  set += 'c'                 // add a character
-  set += true                // add a boolean value
-  set += main _              // add the main function
-  val iter: Iterator[Any] = set.iterator
-  while (iter.hasNext) {
-    println(iter.next.toString())
-  }
-}
+scala> var list: List[Any] = List()
+list: List[Any] = List()
+
+scala> list = list :+ "This is a string"
+list: List[Any] = List(This is a string)
+
+scala> list = list :+ 732
+list: List[Any] = List(This is a string, 732)
+
+scala> list = list :+ 'c'
+list: List[Any] = List(This is a string, 732, c)
+
+scala> list = list :+ true
+list: List[Any] = List(This is a string, 732, c, true)
+
+scala> list = list :+ (() => "This is an anonymous function returning a string")
+list: List[Any] = List(This is a string, 732, c, true, $$Lambda$1095/599060649@108a7fff)
 ```
 
-The program declares an application `UnifiedTypes` in form of a top-level [singleton object](singleton-objects.html) extending `App`. The application defines a local variable `set` which refers to an instance of class `LinkedHashSet[Any]`. The program adds various elements to this set. The elements have to conform to the declared set element type `Any`. In the end, string representations of all elements are printed out.
+The program defines a variable `list` which refers to an instance of class `List[Any]`. The program adds elements of various types to this list.
 
-Here is the output of the program:
+When you print each element, it will output something like the following:
 
-```
+```tut
+scala> list.foreach(element => println(element))
 This is a string
 732
 c
 true
-<function>
+$line15.$read$$iw$$iw$$$Lambda$1095/599060649@108a7fff
 ```

--- a/tutorials/tour/unified-types.md
+++ b/tutorials/tour/unified-types.md
@@ -10,7 +10,7 @@ next-page: classes
 previous-page: tour-of-scala
 ---
 
-In Scala, all values are instance of a class, including numerical values and functions. The diagram below illustrates the class hierarchy.
+In Scala, all values are instances of a class, including numerical values and functions. The diagram below illustrates the class hierarchy.
 
 ![Scala Type Hierarchy]({{ site.baseurl }}/resources/images/classhierarchy.img_assist_custom.png)
 
@@ -18,7 +18,7 @@ In Scala, all values are instance of a class, including numerical values and fun
 
 The superclass of all classes `scala.Any` has two direct subclasses: `scala.AnyVal` and `scala.AnyRef`.
 
-`scala.AnyVal` represents value classes. All value classes are not nullable and predefined; they correspond to the primitive types of Java-like languages. Note that the diagram above also shows implicit conversions between the value classes.
+`scala.AnyVal` represents value classes. All value classes are non-nullable and predefined; they correspond to the primitive types of Java-like languages. Note that the diagram above also shows implicit conversions between the value classes.
 
 `scala.AnyRef` represents reference classes. All non-value classes are defined as reference class. Every user-defined class in Scala implicitly extends `scala.AnyRef`. If Scala is used in the context of a Java runtime environment, `scala.AnyRef` corresponds to `java.lang.Object`.
 
@@ -44,7 +44,7 @@ The application defines a variable `list` of type `List[Any]`. The list is initi
 
 Here is the output of the program:
 
-```tut
+```
 a string
 732
 c

--- a/tutorials/tour/unified-types.md
+++ b/tutorials/tour/unified-types.md
@@ -40,7 +40,9 @@ object UnifiedTypes extends App {
 
 The program declares an application `UnifiedTypes` in form of a top-level [singleton object](singleton-objects.html) extending [`App`](http://www.scala-lang.org/api/2.12.x/scala/App.html) so that the body of it acts as a main function.
 
-The application defines a variable `list` of type `List[Any]`. The list is initialized with elements of various types, and they all are instance of `scala.Any`. In the end, the application outputs something like below:
+The application defines a variable `list` of type `List[Any]`. The list is initialized with elements of various types, but they all are instance of `scala.Any`, so you can add them to the list.
+
+In the end, the application outputs something like below:
 
 ```tut
 a string

--- a/tutorials/tour/unified-types.md
+++ b/tutorials/tour/unified-types.md
@@ -41,7 +41,7 @@ object UnifiedTypes extends App {
 The application defines a variable `list` which refers to an instance of class `List[Any]`. The list is initialized with elements of various types. In the end, the application outputs something like below:
 
 ```tut
-This is a string
+a string
 732
 c
 true

--- a/tutorials/tour/unified-types.md
+++ b/tutorials/tour/unified-types.md
@@ -25,20 +25,16 @@ The superclass of all classes `scala.Any` has two direct subclasses: `scala.AnyV
 Here is an example that demonstrates that strings, integers, characters, boolean values, and functions are all objects just like every other object:
 
 ```tut
-object UnifiedTypes extends App {
-  val list: List[Any] = List(
-    "a string",
-    732,  // an integer
-    'c',  // a character
-    true, // a boolean value
-    () => "an anonymous function returning a string"
-  )
+val list: List[Any] = List(
+  "a string",
+  732,  // an integer
+  'c',  // a character
+  true, // a boolean value
+  () => "an anonymous function returning a string"
+)
 
-  list.foreach(element => println(element))
-}
-```
-
-The program declares an application `UnifiedTypes` in form of a top-level [singleton object](singleton-objects.html) extending [`App`](http://www.scala-lang.org/api/2.12.x/scala/App.html) so that the body of it acts as a main function.
+list.foreach(element => println(element))
+````
 
 The application defines a variable `list` of type `List[Any]`. The list is initialized with elements of various types, but they all are instance of `scala.Any`, so you can add them to the list.
 


### PR DESCRIPTION
- It simplifies wordings by removing unnecessary and redundant information.
- It says `scala.AnyVal` is non-nullable, which I think is a critical information to communicate.
- It removes `scala.ScalaObject`.
    - I still don't know exactly what it is, but there is [a comment](http://docs.scala-lang.org/tutorials/tour/unified-types#comment-2685040354) saying it is deprecated. I thought it's no harm to take it out of the picture, but correct me if it's still important.
- In the example, it uses `List[Any]` instead of `scala.collection.mutable.LinkedHashSet[Any]`.
    - I think more people are familiar with list than linked hash set.
- In the example, it uses anonymous function instead of partially applied main function.
    - I think using partially applied function here throws out new comers, while I expect many of them are already familiar with anonymous functions.
- In the example, it uses `foreach` instead of `iterator`.
- It removes use of `object` or `App` because they are unrelated.
