### PR TITLE
Add Basics tutorial page

### DIFF
--- a/tutorials/tour/abstract-types.md
+++ b/tutorials/tour/abstract-types.md
@@ -5,7 +5,7 @@ title: Abstract Types
 disqus: true
 
 tutorial: scala-tour
-num: 22
+num: 23
 next-page: compound-types
 previous-page: inner-classes
 ---

--- a/tutorials/tour/annotations.md
+++ b/tutorials/tour/annotations.md
@@ -5,7 +5,7 @@ title: Annotations
 disqus: true
 
 tutorial: scala-tour
-num: 31
+num: 32
 next-page: default-parameter-values
 previous-page: automatic-closures
 ---

--- a/tutorials/tour/anonymous-function-syntax.md
+++ b/tutorials/tour/anonymous-function-syntax.md
@@ -5,7 +5,7 @@ title: Anonymous Function Syntax
 disqus: true
 
 tutorial: scala-tour
-num: 6
+num: 7
 next-page: higher-order-functions
 previous-page: mixin-class-composition
 ---

--- a/tutorials/tour/automatic-closures.md
+++ b/tutorials/tour/automatic-closures.md
@@ -5,7 +5,7 @@ title: Automatic Type-Dependent Closure Construction
 disqus: true
 
 tutorial: scala-tour
-num: 30
+num: 31
 next-page: annotations
 previous-page: operators
 ---

--- a/tutorials/tour/basics.md
+++ b/tutorials/tour/basics.md
@@ -24,18 +24,24 @@ It is a perfect way for anybody to experiment a piece of Scala code anywhere, an
 
 ## Variables
 
-You can define variables with `var` keyword.
-
-```
-var x = 1 + 1
-x += 1
-```
-
-Often, you want your variables to be immutable. You can use `val` keyword in that case.
+You can define variables with the `val` keyword.
 
 ```
 val x = 1 + 1
-x += 1 // This does not compile because you declared the variable with "val" keyword
+```
+
+Variables defined by `val` cannot be re-assigned and are immutable in that sense.
+
+```
+val x = 1 + 1
+x += 2 // This does not compile because it is re-assigning the variable.
+```
+
+If you need a mutable variable, you can use the `var` keyword instead.
+
+```
+var y = 1 + 1
+y += 2 // This compiles because "y" is declared with "var" keyword.
 ```
 
 Type of variables can be inferred, but you can also explicitly state type like below.

--- a/tutorials/tour/basics.md
+++ b/tutorials/tour/basics.md
@@ -22,32 +22,33 @@ You can run Scala in your browser by using [ScalaFiddle](https://scalafiddle.io)
 
 It is a perfect way for anybody to experiment with a piece of Scala code anywhere, anytime!
 
-## Variables
+## Values and Variables
 
-You can define variables with the `val` keyword.
-
-```
-val x = 1 + 1
-```
-
-Variables defined by `val` cannot be re-assigned and are immutable in that sense.
+You can define values (a.k.a. immutable variables) with the `val` keyword.
 
 ```
 val x = 1 + 1
-x += 2 // This does not compile because it is re-assigning the variable.
 ```
 
-If you need to mutate variables, you can use the `var` keyword instead.
+Values cannot be re-assigned and are immutable in that sense.
+
+```
+val x = 1 + 1
+x = 3 // This does not compile because it is re-assigning the value.
+```
+
+If you need to re-assign, you must declare them as variables using the `var` keyword.
 
 ```
 var y = 1 + 1
-y += 2 // This compiles because "y" is declared with "var" keyword.
+y = 3 // This compiles because "y" is declared with "var" keyword.
 ```
 
-Type of variables can be inferred, but you can also explicitly state type like below.
+Types of values and variables can be inferred, but you can also explicitly state types like below.
 
 ```
 val x: Int = 1 + 1
+var y: Int = 1 + 1
 ```
 
 ## Functions

--- a/tutorials/tour/basics.md
+++ b/tutorials/tour/basics.md
@@ -75,9 +75,83 @@ println(point) // (1, 2)
 
 We will cover classes in depth [later](classes.md).
 
+## Case Classes
+
+By default, classes are compared by reference. If you want to compare them by values, you need to override `equals` and `hashCode` methods.
+
+```
+class Point(val x: Int, val y: Int) {
+  override def equals(o: Any) = o match {
+    case that: Point => x == that.x && y == that.y
+    case _ => false
+  }
+  override def hashCode = (x.hashCode << 16) + y.hashCode
+}
+```
+
+While it works, it's tedious to define those methods for all classes you want to compare by value.
+
+Thankfully, Scala has another type of class called `case class` that's compared by value by default.
+
+```
+case class Point(x: Int, y: Int)
+```
+
+You can instantiate case classes without `new` keyword.
+
+```
+val point = Point(1, 2) // no "new" here
+val anotherPoint = Point(1, 2)
+val yetAnotherPoint = Point(2, 2)
+println(point == anotherPoint) // true
+println(point == yetAnotherPoint) // false
+```
+
+Case classes are immutable by default, but it also provides `copy` method so that you can easily create another instance of the class while reusing the values from exiting instances.
+
+Using `copy` method, you can also write the above code like below.
+
+```
+val point = Point(1, 2)
+val anotherPoint = point.copy()
+val yetAnotherPoint = point.copy(x = 2)
+println(point == anotherPoint) // true
+println(point == yetAnotherPoint) // false
+```
+
+Because of case classes, you almost never see classes overriding `equals` and `hashCode` methods in Scala.
+
+There are many other features you get out-of-the-box by using case classes. We will cover them in depth [later](case-classes.md).
+
+## Singleton Objects
+
+You can define singleton objects with `object` keyword.
+
+```
+object IdFactory {
+  private var counter = 0
+
+  def create(): Int = {
+    counter += 1
+    counter
+  }
+}
+```
+
+You can access singleton objects just by referring its name.
+
+```
+val newId: Int = IdFactory.create()
+println(newId) // 1
+val newerId: Int = IdFactory.create()
+println(newerId) // 2
+```
+
+We will cover singleton objects in depth [later](singleton-objects.md).
+
 ## Traits
 
-Traits define types as signature of fields and methods.
+Traits define specification of types as signature of fields and methods.
 
 You can define traits with `trait` keyword.
 
@@ -111,80 +185,6 @@ class MyPoint(var x: Int, var y: Int) extends Point {
 ```
 
 We will cover traits in depth [later](traits.md).
-
-## Case Classes
-
-By default, classes are compared by reference. If you want to compare them by values, you need to override `equals` and `hashCode` methods.
-
-```
-class Point(x: Int, y: Int) {
-  override def equals(o: Any) = o match {
-    case that: Point => x == that.x && y == that.y
-    case _ => false
-  }
-  override def hashCode = (x.hashCode << 16) + y.hashCode
-}
-```
-
-It works, but it's tedious to define those methods for all classes you want to compare by value.
-
-Thankfully, Scala has another type of class called `case class` that's compared by value by default.
-
-```
-case class Point(x: Int, y: Int)
-```
-
-Because of case classes, you almost never see Scala classes overriding `equals` and `hashCode` methods.
-
-You can instantiate case classes without `new` keyword.
-
-```
-val point = Point(1, 2) // no "new" here
-val anotherPoint = Point(1, 2)
-val yetAnotherPoint = Point(2, 2)
-println(point == anotherPoint) // true
-println(point == yetAnotherPoint) // false
-```
-
-Case classes are immutable by default, but it also provides `copy` method so that you can easily create another instance of the class while reusing the values from exiting instances.
-
-Using `copy` method, you can also write the above code like below.
-
-```
-val point = Point(1, 2)
-val anotherPoint = point.copy()
-val yetAnotherPoint = point.copy(x = 2)
-println(point == anotherPoint) // true
-println(point == yetAnotherPoint) // false
-```
-
-There are many other features you get out-of-the-box by using case classes. We will cover them in depth [later](case-classes.md).
-
-## Singleton Objects
-
-You can define singleton objects with `object` keyword.
-
-```
-object IdFactory {
-  private var counter = 0
-
-  def create(): Int = {
-    counter += 1
-    counter
-  }
-}
-```
-
-You can access singleton objects just by referring its name.
-
-```
-val newId: Int = IdFactory.create()
-println(newId) // 1
-val newerId: Int = IdFactory.create()
-println(newerId) // 2
-```
-
-We will cover singleton objects in depth [later](singleton-objects.md).
 
 ## Main Method
 

--- a/tutorials/tour/basics.md
+++ b/tutorials/tour/basics.md
@@ -22,48 +22,79 @@ You can run Scala in your browser by using [ScalaFiddle](https://scalafiddle.io)
 
 It is a perfect way for anybody to experiment with a piece of Scala code anywhere, anytime!
 
-## Values and Variables
+## Expressions
 
-You can define values (a.k.a. immutable variables) with the `val` keyword.
+Expressions are computable statements.
+
+You can output results of expressions using the `println`.
+
+```
+println(1) // 1
+println(1 + 1) // 2
+println("Hello!") // Hello!
+println("Hello," + " world!") // Hello, world!
+```
+
+You can name the result of an expression by using the `val` keyword.
 
 ```
 val x = 1 + 1
+println(x) // 2
 ```
 
-Values cannot be re-assigned and are immutable in that sense.
+Named results are called values. For example, in above case, `x` is called a value. Values only hold results of expressions, so they will not re-compute expressions when referenced.
+
+Values cannot be re-assigned.
 
 ```
 val x = 1 + 1
-x = 3 // This does not compile because it is re-assigning the value.
+x = 3 // This does not compile.
 ```
 
-If you need to re-assign, you must declare them as variables using the `var` keyword.
-
-```
-var y = 1 + 1
-y = 3 // This compiles because "y" is declared with "var" keyword.
-```
-
-Types of values and variables can be inferred, but you can also explicitly state types like below.
+Types of values can be inferred, but you can also explicitly state types like below.
 
 ```
 val x: Int = 1 + 1
-var y: Int = 1 + 1
+```
+
+You can create a single expression out of multiple statements by wrapping them with `{}`. When statements are wrapped with `{}`, the result of the last statement will be the result of the overall expression.
+
+```
+println({
+  val x = 1 + 1
+  x + 1
+}) // 3
+```
+
+## Variables
+
+Variables are similar to values except you can re-assign results they hold. You can define variables with the `var` keyword.
+
+```
+var x = 1 + 1
+x = 3 // This compiles because "x" is declared with the "var" keyword.
+println(x) // 3
+```
+
+Just like values, you can also explicitly state types of variables like below.
+
+```
+var x: Int = 1 + 1
 ```
 
 ## Functions
 
-You can define functions that returns a given integer + 1 like below.
+Functions are expressions with parameters.
+
+You can define a function that returns a given integer + 1 like below.
 
 ```
 (x: Int) => x + 1
 ```
 
-Left hand side of `=>` is parameter(s) and right hand side of `=>` is body.
+Left hand side of `=>` is a list of parameters and right hand side of `=>` is an expression taking the parameters.
 
-Notice that the function has no `return` keyword. This is because, in Scala, the last expression of the function is automatically returned.
-
-You can also assign functions to variables.
+You can also name functions.
 
 ```
 val addOne = (x: Int) => x + 1
@@ -84,36 +115,25 @@ val getTheAnswer = () => 42
 println(getTheAnswer()) // 42
 ```
 
-If your function body spans across multiple lines, you must wrap them with `{}`.
-
-```
-val greet = (name: String) => {
-  println("Hello, " + name + "!")
-  println("How are you doing today?")
-}
-greet("Scala developer")
-// Hello, Scala developer!
-// How are you doing today?
-```
-
 We will cover functions in depth [later](anonymous-function-syntax.md).
 
 ## Methods
 
 Methods look and behave very similar to functions, but there are a few key differences between them.
 
-Methods are defined like below with the `def` keyword followed by its name, parameter(s), return type, and body.
+Methods are defined like below with the `def` keyword followed by its name, a list of parameter groups, return type, and an expression.
 
 ```
 def add(x: Int, y: Int): Int = x + y
 println(add(1, 2)) // 3
 ```
 
-Methods cannot be assigned to variables.
+Methods cannot be named with the `val` or `var` keywords.
 
 ```
 def add(x: Int, y: Int): Int = x + y
 val add2 = add // This does not compile.
+var add3 = add // This does not compile either.
 ```
 
 Methods can take multiple parameter groups.
@@ -123,7 +143,7 @@ def addThenMultiply(x: Int, y: Int)(multiplier: Int): Int = (x + y) * multiplier
 println(addThenMultiply(1, 2)(3)) // 9
 ```
 
-Or no parameter group at all.
+Or no parameter groups at all.
 
 ```
 def name: String = System.getProperty("name")
@@ -165,7 +185,11 @@ You can instantiate case classes without `new` keyword.
 val point = Point(1, 2)
 val anotherPoint = Point(1, 2)
 val yetAnotherPoint = Point(2, 2)
+```
 
+And they are compared by values.
+
+```
 if (point == anotherPoint) {
   println(point + " and " + anotherPoint + " are the same.")
 } else {
@@ -223,7 +247,7 @@ trait Greeter {
 }
 ```
 
-Traits can also have default implementation.
+Traits can also have default implementations.
 
 ```
 trait Greeter {
@@ -231,7 +255,7 @@ trait Greeter {
 }
 ```
 
-You can extend traits with the `extends` keyword and override their implementation with the `override` keyword.
+You can extend traits with the `extends` keyword and override their implementations with the `override` keyword.
 
 ```
 class DefaultGreeter extends Greeter
@@ -252,6 +276,8 @@ customGreeter.greet("Scala developer") // How are you, Scala developer?
 We will cover traits in depth [later](traits.md).
 
 ## Main Method
+
+Main method is an entry point of a program.
 
 Using objects, you can define main methods like below.
 

--- a/tutorials/tour/basics.md
+++ b/tutorials/tour/basics.md
@@ -52,18 +52,59 @@ val x: Int = 1 + 1
 
 ## Functions
 
-You can define functions like below.
+You can define functions that returns a given integer + 1 like below.
 
 ```
-(name: String) => println("Hello, " + name + "!")
+(x: Int) => x + 1
 ```
+
+Left hand side of `=>` is parameter(s) and right hand side of it is body.
+
+Notice that the function has no `return` keyword. This is because, in Scala, the last expression of the function is automatically returned.
 
 You can also assign functions to variables.
 
 ```
-val greet = (name: String) => println("Hello, " + name + "!")
-greet("Scala") // Hello, Scala!
+val addOne = (x: Int) => x + 1
+println(addOne(1)) // 2
 ```
+
+Or it can take multiple parameters.
+
+```
+val add = (x: Int, y: Int) => x + y
+println(add(1, 2)) // 3
+```
+
+Or it can take no parameters.
+
+```
+val now = () => 42
+println(now()) // 42
+```
+
+If your function body spans across multiple lines, you can wrap them with `{}`.
+
+```
+val greet = (name: String) => {
+  println("Hello, " + name + "!")
+  println("How are you doing today?")
+}
+greet("Scala developer")
+// Hello, Scala developer!
+// How are you doing today?
+```
+
+You can write the corresponding function types like below.
+
+```
+Int => Int
+(Int, Int) => Int
+() => Int
+String => Unit // "Unit" is equivalent of "void" in Scala.
+```
+
+Left hand side of `=>` is parameter type(s) and right hand side of it is return type.
 
 We will cover functions in depth [later](anonymous-function-syntax.md).
 

--- a/tutorials/tour/basics.md
+++ b/tutorials/tour/basics.md
@@ -12,6 +12,16 @@ previous-page: tour-of-scala
 
 In this page, we will cover basics of Scala.
 
+## Running Scala on Browser
+
+You can run Scala on browser by using [ScalaFiddle](https://scalafiddle.io).
+
+1. Go to https://scalafiddle.io.
+2. Copy and paste `println("Hello, world!")` to the left pane.
+3. Hit "Run" button and see it prints "Hello, world!" on the right pane.
+
+It is a perfect way for anybody to experiment a piece of Scala code anywhere, anytime!
+
 ## Variables
 
 You can define variables with `var` keyword.

--- a/tutorials/tour/basics.md
+++ b/tutorials/tour/basics.md
@@ -10,26 +10,28 @@ next-page: unified-types
 previous-page: tour-of-scala
 ---
 
-## Values and Variables
+In this page, we will cover basics of Scala.
 
-You can define values with `val` keyword.
+## Variables
 
-```
-val x = 1 + 1
-```
-
-When defined with `val`, you cannot mutate the binding.
-
-```
-val x = 1 + 1
-x += 1 // This does not compile because you are mutating values defined with "val" keyword
-```
-
-You can use `var` instead to make it variable, allowing mutation.
+You can define variables with `var` keyword.
 
 ```
 var x = 1 + 1
 x += 1
+```
+
+Often, you want your variables to be immutable. You can use `val` keyword in that case.
+
+```
+val x = 1 + 1
+x += 1 // This does not compile because you declared the variable with "val" keyword
+```
+
+Type of variables can be inferred, but you can also explicitly state type like below.
+
+```
+val x: Int = 1 + 1
 ```
 
 ## Functions
@@ -75,7 +77,7 @@ We will cover classes in depth [later](classes.md).
 
 ## Traits
 
-Traits are used to define object types by specifying the signature of fields and methods.
+Traits define types as signature of fields and methods.
 
 You can define traits with `trait` keyword.
 
@@ -146,7 +148,7 @@ println(point == yetAnotherPoint) // false
 
 Case classes are immutable by default, but it also provides `copy` method so that you can easily create another instance of the class while reusing the values from exiting instances.
 
-Using `copy` method, you can write the above code like below.
+Using `copy` method, you can also write the above code like below.
 
 ```
 val point = Point(1, 2)
@@ -156,7 +158,7 @@ println(point == anotherPoint) // true
 println(point == yetAnotherPoint) // false
 ```
 
-There are many other features you get out-of-box by using case classes. We will cover them [later](case-classes.md).
+There are many other features you get out-of-the-box by using case classes. We will cover them in depth [later](case-classes.md).
 
 ## Singleton Objects
 
@@ -171,6 +173,15 @@ object IdFactory {
     counter
   }
 }
+```
+
+You can access singleton objects just by referring its name.
+
+```
+val newId: Int = IdFactory.create()
+println(newId) // 1
+val newerId: Int = IdFactory.create()
+println(newerId) // 2
 ```
 
 We will cover singleton objects in depth [later](singleton-objects.md).

--- a/tutorials/tour/basics.md
+++ b/tutorials/tour/basics.md
@@ -152,21 +152,7 @@ We will cover classes in depth [later](classes.md).
 
 ## Case Classes
 
-By default, classes are compared by reference. If you want to compare them by values, you need to override `equals` and `hashCode` methods.
-
-```
-class Point(val x: Int, val y: Int) {
-  override def equals(o: Any) = o match {
-    case that: Point => x == that.x && y == that.y
-    case _ => false
-  }
-  override def hashCode = (x.hashCode << 16) + y.hashCode
-}
-```
-
-While it works, it's tedious to define those methods for all classes you want to compare by value.
-
-Thankfully, Scala has another type of class called `case class` that's compared by value by default.
+Scala has a special type of class called case class that's immutable by default and compared by value. You can define case classes with the `case class` keyword.
 
 ```
 case class Point(x: Int, y: Int)
@@ -175,28 +161,26 @@ case class Point(x: Int, y: Int)
 You can instantiate case classes without `new` keyword.
 
 ```
-val point = Point(1, 2) // no "new" here
+val point = Point(1, 2)
 val anotherPoint = Point(1, 2)
 val yetAnotherPoint = Point(2, 2)
-println(point == anotherPoint) // true
-println(point == yetAnotherPoint) // false
+
+if (point == anotherPoint) {
+  println(point + " and " + anotherPoint + " are the same.")
+} else {
+  println(point + " and " + anotherPoint + " are different.")
+}
+// Point(1,2) and Point(1,2) are the same.
+
+if (point == yetAnotherPoint) {
+  println(point + " and " + yetAnotherPoint + " are the same.")
+} else {
+  println(point + " and " + yetAnotherPoint + " are different.")
+}
+// Point(1,2) and Point(2,2) are different.
 ```
 
-Case classes are immutable by default, but it also provides `copy` method so that you can easily create another instance of the class while reusing the values from exiting instances.
-
-Using `copy` method, you can also write the above code like below.
-
-```
-val point = Point(1, 2)
-val anotherPoint = point.copy()
-val yetAnotherPoint = point.copy(x = 2)
-println(point == anotherPoint) // true
-println(point == yetAnotherPoint) // false
-```
-
-Because of case classes, you almost never see classes overriding `equals` and `hashCode` methods in Scala.
-
-There are many other features you get out-of-the-box by using case classes. We will cover them in depth [later](case-classes.md).
+There is a lot more to case classes that we'd like to introduce, and we are convinced you will fall in love with it! We will cover them in depth [later](case-classes.md).
 
 ## Singleton Objects
 

--- a/tutorials/tour/basics.md
+++ b/tutorials/tour/basics.md
@@ -182,9 +182,11 @@ if (point == yetAnotherPoint) {
 
 There is a lot more to case classes that we'd like to introduce, and we are convinced you will fall in love with it! We will cover them in depth [later](case-classes.md).
 
-## Singleton Objects
+## Objects
 
-You can define singleton objects with `object` keyword.
+Objects are single instances of its own definition. You can think of them as singletons of their own classes.
+
+You can define objects with the `object` keyword.
 
 ```
 object IdFactory {
@@ -197,7 +199,7 @@ object IdFactory {
 }
 ```
 
-You can access singleton objects just by referring its name.
+You can access objects by referring its name.
 
 ```
 val newId: Int = IdFactory.create()
@@ -206,7 +208,7 @@ val newerId: Int = IdFactory.create()
 println(newerId) // 2
 ```
 
-We will cover singleton objects in depth [later](singleton-objects.md).
+We will cover objects in depth [later](singleton-objects.md).
 
 ## Traits
 

--- a/tutorials/tour/basics.md
+++ b/tutorials/tour/basics.md
@@ -1,0 +1,196 @@
+---
+layout: tutorial
+title: Basics
+
+disqus: true
+
+tutorial: scala-tour
+num: 2
+next-page: unified-types
+previous-page: tour-of-scala
+---
+
+## Values and Variables
+
+You can define values with `val` keyword.
+
+```
+val x = 1 + 1
+```
+
+When defined with `val`, you cannot mutate the binding.
+
+```
+val x = 1 + 1
+x += 1 // This does not compile because you are mutating values defined with "val" keyword
+```
+
+You can use `var` instead to make it variable, allowing mutation.
+
+```
+var x = 1 + 1
+x += 1
+```
+
+## Functions
+
+You can define functions like below.
+
+```
+(name: String) => println("Hello, " + name + "!")
+```
+
+You can also assign functions to variables.
+
+```
+val greet = (name: String) => println("Hello, " + name + "!")
+greet("Scala") // Hello, Scala!
+```
+
+We will cover functions in depth [later](anonymous-function-syntax.md).
+
+## Classes
+
+You can define classes with `class` keyword.
+
+```
+class Point(var x: Int, var y: Int) {
+  def move(dx: Int, dy: Int): Unit = {
+    x = x + dx
+    y = y + dy
+  }
+
+  override def toString: String = "(" + x + ", " + y + ")"
+}
+```
+
+You can instantiate classes with `new` keyword.
+
+```
+val point = new Point(1, 2)
+println(point) // (1, 2)
+```
+
+We will cover classes in depth [later](classes.md).
+
+## Traits
+
+Traits are used to define object types by specifying the signature of fields and methods.
+
+You can define traits with `trait` keyword.
+
+```
+trait Point {
+  var x: Int
+  var y: Int
+}
+```
+
+Traits can also have implementation.
+
+```
+trait Point {
+  var x: Int
+  var y: Int
+  
+  override def toString: String = "(" + x + ", " + y + ")"
+}
+```
+
+You can extend traits with `extends` keyword.
+
+```
+class MyPoint(var x: Int, var y: Int) extends Point {
+  def move(dx: Int, dy: Int): Unit = {
+    x = x + dx
+    y = y + dy
+  }
+}
+```
+
+We will cover traits in depth [later](traits.md).
+
+## Case Classes
+
+By default, classes are compared by reference. If you want to compare them by values, you need to override `equals` and `hashCode` methods.
+
+```
+class Point(x: Int, y: Int) {
+  override def equals(o: Any) = o match {
+    case that: Point => x == that.x && y == that.y
+    case _ => false
+  }
+  override def hashCode = (x.hashCode << 16) + y.hashCode
+}
+```
+
+It works, but it's tedious to define those methods for all classes you want to compare by value.
+
+Thankfully, Scala has another type of class called `case class` that's compared by value by default.
+
+```
+case class Point(x: Int, y: Int)
+```
+
+Because of case classes, you almost never see Scala classes overriding `equals` and `hashCode` methods.
+
+You can instantiate case classes without `new` keyword.
+
+```
+val point = Point(1, 2) // no "new" here
+val anotherPoint = Point(1, 2)
+val yetAnotherPoint = Point(2, 2)
+println(point == anotherPoint) // true
+println(point == yetAnotherPoint) // false
+```
+
+Case classes are immutable by default, but it also provides `copy` method so that you can easily create another instance of the class while reusing the values from exiting instances.
+
+Using `copy` method, you can write the above code like below.
+
+```
+val point = Point(1, 2)
+val anotherPoint = point.copy()
+val yetAnotherPoint = point.copy(x = 2)
+println(point == anotherPoint) // true
+println(point == yetAnotherPoint) // false
+```
+
+There are many other features you get out-of-box by using case classes. We will cover them [later](case-classes.md).
+
+## Singleton Objects
+
+You can define singleton objects with `object` keyword.
+
+```
+object IdFactory {
+  private var counter = 0
+
+  def create(): Int = {
+    counter += 1
+    counter
+  }
+}
+```
+
+We will cover singleton objects in depth [later](singleton-objects.md).
+
+## Main Method
+
+Using singleton objects, you can define main methods like below.
+
+```
+object Main {
+  def main(args: Array[String]): Unit = {
+    println("Hello, world!")
+  }
+}
+```
+
+Because every runnable application has a main method, Scala also provides a more convenient way of defining your main method by extending `App` trait.
+
+```
+object Main extends App {
+  println("Hello, world!")
+}
+```

--- a/tutorials/tour/basics.md
+++ b/tutorials/tour/basics.md
@@ -95,17 +95,6 @@ greet("Scala developer")
 // How are you doing today?
 ```
 
-You can write the corresponding function types like below.
-
-```
-Int => Int
-(Int, Int) => Int
-() => Int
-String => Unit // "Unit" is equivalent of "void" in Scala.
-```
-
-Left hand side of `=>` is parameter type(s) and right hand side of it is return type.
-
 We will cover functions in depth [later](anonymous-function-syntax.md).
 
 ## Classes

--- a/tutorials/tour/basics.md
+++ b/tutorials/tour/basics.md
@@ -252,20 +252,10 @@ We will cover traits in depth [later](traits.md).
 
 ## Main Method
 
-Using singleton objects, you can define main methods like below.
+Using objects, you can define main methods like below.
 
 ```
 object Main {
-  def main(args: Array[String]): Unit = {
-    println("Hello, world!")
-  }
-}
-```
-
-Because every runnable application has a main method, Scala also provides a more convenient way of defining your main method by extending `App` trait.
-
-```
-object Main extends App {
-  println("Hello, world!")
+  def main(args: Array[String]): Unit = println("Hello, Scala developer!")
 }
 ```

--- a/tutorials/tour/basics.md
+++ b/tutorials/tour/basics.md
@@ -79,8 +79,8 @@ println(add(1, 2)) // 3
 Or it can take no parameters.
 
 ```
-val now = () => 42
-println(now()) // 42
+val getTheAnswer = () => 42
+println(getTheAnswer()) // 42
 ```
 
 If your function body spans across multiple lines, you can wrap them with `{}`.
@@ -133,24 +133,19 @@ There are some other differences, but for now, you can think of them as somethin
 
 ## Classes
 
-You can define classes with `class` keyword.
+You can define classes with the `class` keyword followed by its name and constructor parameters.
 
 ```
-class Point(var x: Int, var y: Int) {
-  def move(dx: Int, dy: Int): Unit = {
-    x = x + dx
-    y = y + dy
-  }
-
-  override def toString: String = "(" + x + ", " + y + ")"
+class Greeter(prefix: String, postfix: String) {
+  def greet(name: String): Unit = println(prefix + name + postfix)
 }
 ```
 
-You can instantiate classes with `new` keyword.
+You can instantiate classes with the `new` keyword.
 
 ```
-val point = new Point(1, 2)
-println(point) // (1, 2)
+val greeter = new Greeter("Hello, ", "!")
+greeter.greet("Scala developer") // Hello, Scala developer!
 ```
 
 We will cover classes in depth [later](classes.md).

--- a/tutorials/tour/basics.md
+++ b/tutorials/tour/basics.md
@@ -35,7 +35,9 @@ println("Hello!") // Hello!
 println("Hello," + " world!") // Hello, world!
 ```
 
-You can name the result of an expression by using the `val` keyword.
+### Values
+
+You can name results of expressions by using the `val` keyword.
 
 ```
 val x = 1 + 1
@@ -57,16 +59,7 @@ Types of values can be inferred, but you can also explicitly state types like be
 val x: Int = 1 + 1
 ```
 
-You can create a single expression out of multiple statements by wrapping them with `{}`. When statements are wrapped with `{}`, the result of the last statement will be the result of the overall expression.
-
-```
-println({
-  val x = 1 + 1
-  x + 1
-}) // 3
-```
-
-## Variables
+### Variables
 
 Variables are similar to values except you can re-assign results they hold. You can define variables with the `var` keyword.
 
@@ -80,6 +73,19 @@ Just like values, you can also explicitly state types of variables like below.
 
 ```
 var x: Int = 1 + 1
+```
+
+### Blocks
+
+You can create a single expression out of multiple statements by wrapping them with `{}`. We call them blocks or block expressions.
+
+The result of the last statement of the block will be the result of the overall block.
+
+```
+println({
+  val x = 1 + 1
+  x + 1
+}) // 3
 ```
 
 ## Functions

--- a/tutorials/tour/basics.md
+++ b/tutorials/tour/basics.md
@@ -12,15 +12,15 @@ previous-page: tour-of-scala
 
 In this page, we will cover basics of Scala.
 
-## Running Scala on Browser
+## Trying Scala in the Browser
 
-You can run Scala on browser by using [ScalaFiddle](https://scalafiddle.io).
+You can run Scala in your browser by using [ScalaFiddle](https://scalafiddle.io).
 
 1. Go to https://scalafiddle.io.
 2. Copy and paste `println("Hello, world!")` to the left pane.
 3. Hit "Run" button and see it prints "Hello, world!" on the right pane.
 
-It is a perfect way for anybody to experiment a piece of Scala code anywhere, anytime!
+It is a perfect way for anybody to experiment with a piece of Scala code anywhere, anytime!
 
 ## Variables
 

--- a/tutorials/tour/basics.md
+++ b/tutorials/tour/basics.md
@@ -152,7 +152,7 @@ We will cover classes in depth [later](classes.md).
 
 ## Case Classes
 
-Scala has a special type of class called case class that's immutable by default and compared by value. You can define case classes with the `case class` keyword.
+Scala has a special type of class called case class that's immutable and compared by value by default. You can define case classes with the `case class` keyword.
 
 ```
 case class Point(x: Int, y: Int)
@@ -184,7 +184,7 @@ There is a lot more to case classes that we'd like to introduce, and we are conv
 
 ## Objects
 
-Objects are single instances of its own definition. You can think of them as singletons of their own classes.
+Objects are single instances of their own definitions. You can think of them as singletons of their own classes.
 
 You can define objects with the `object` keyword.
 

--- a/tutorials/tour/basics.md
+++ b/tutorials/tour/basics.md
@@ -37,7 +37,7 @@ val x = 1 + 1
 x += 2 // This does not compile because it is re-assigning the variable.
 ```
 
-If you need a mutable variable, you can use the `var` keyword instead.
+If you need to mutate variables, you can use the `var` keyword instead.
 
 ```
 var y = 1 + 1

--- a/tutorials/tour/basics.md
+++ b/tutorials/tour/basics.md
@@ -217,32 +217,35 @@ Traits define specification of types as signature of fields and methods.
 You can define traits with `trait` keyword.
 
 ```
-trait Point {
-  var x: Int
-  var y: Int
+trait Greeter {
+  def greet(name: String): Unit
 }
 ```
 
-Traits can also have implementation.
+Traits can also have default implementation.
 
 ```
-trait Point {
-  var x: Int
-  var y: Int
-  
-  override def toString: String = "(" + x + ", " + y + ")"
+trait Greeter {
+  def greet(name: String): Unit = println("Hello, " + name + "!")
 }
 ```
 
-You can extend traits with `extends` keyword.
+You can extend traits with the `extends` keyword and override their implementation with the `override` keyword.
 
 ```
-class MyPoint(var x: Int, var y: Int) extends Point {
-  def move(dx: Int, dy: Int): Unit = {
-    x = x + dx
-    y = y + dy
+class DefaultGreeter extends Greeter
+
+class CustomizableGreeter(prefix: String, postfix: String) extends Greeter {
+  override def greet(name: String): Unit = {
+    println(prefix + name + postfix)
   }
 }
+
+val greeter = new DefaultGreeter()
+greeter.greet("Scala developer") // Hello, Scala developer!
+
+val customGreeter = new CustomizableGreeter("How are you, ", "?")
+customGreeter.greet("Scala developer") // How are you, Scala developer?
 ```
 
 We will cover traits in depth [later](traits.md).

--- a/tutorials/tour/basics.md
+++ b/tutorials/tour/basics.md
@@ -59,7 +59,7 @@ You can define functions that returns a given integer + 1 like below.
 (x: Int) => x + 1
 ```
 
-Left hand side of `=>` is parameter(s) and right hand side of it is body.
+Left hand side of `=>` is parameter(s) and right hand side of `=>` is body.
 
 Notice that the function has no `return` keyword. This is because, in Scala, the last expression of the function is automatically returned.
 
@@ -84,7 +84,7 @@ val getTheAnswer = () => 42
 println(getTheAnswer()) // 42
 ```
 
-If your function body spans across multiple lines, you can wrap them with `{}`.
+If your function body spans across multiple lines, you must wrap them with `{}`.
 
 ```
 val greet = (name: String) => {

--- a/tutorials/tour/basics.md
+++ b/tutorials/tour/basics.md
@@ -97,6 +97,40 @@ greet("Scala developer")
 
 We will cover functions in depth [later](anonymous-function-syntax.md).
 
+## Methods
+
+Methods look and behave very similar to functions, but there are a few key differences between them.
+
+Methods are defined like below with the `def` keyword followed by its name, parameter(s), return type, and body.
+
+```
+def add(x: Int, y: Int): Int = x + y
+println(add(1, 2)) // 3
+```
+
+Methods cannot be assigned to variables.
+
+```
+def add(x: Int, y: Int): Int = x + y
+val add2 = add // This does not compile.
+```
+
+Methods can take multiple parameter groups.
+
+```
+def addThenMultiply(x: Int, y: Int)(multiplier: Int): Int = (x + y) * multiplier
+println(addThenMultiply(1, 2)(3)) // 9
+```
+
+Or no parameter group at all.
+
+```
+def name: String = System.getProperty("name")
+println("Hello, " + name + "!")
+```
+
+There are some other differences, but for now, you can think of them as something similar to functions.
+
 ## Classes
 
 You can define classes with `class` keyword.

--- a/tutorials/tour/case-classes.md
+++ b/tutorials/tour/case-classes.md
@@ -5,7 +5,7 @@ title: Case Classes
 disqus: true
 
 tutorial: scala-tour
-num: 10
+num: 11
 next-page: pattern-matching
 previous-page: currying
 ---

--- a/tutorials/tour/classes.md
+++ b/tutorials/tour/classes.md
@@ -5,7 +5,7 @@ title: Classes
 disqus: true
 
 tutorial: scala-tour
-num: 3
+num: 4
 next-page: traits
 previous-page: unified-types
 ---

--- a/tutorials/tour/compound-types.md
+++ b/tutorials/tour/compound-types.md
@@ -5,7 +5,7 @@ title: Compound Types
 disqus: true
 
 tutorial: scala-tour
-num: 23
+num: 24
 next-page: explicitly-typed-self-references
 previous-page: abstract-types
 ---

--- a/tutorials/tour/currying.md
+++ b/tutorials/tour/currying.md
@@ -5,7 +5,7 @@ title: Currying
 disqus: true
 
 tutorial: scala-tour
-num: 9
+num: 10
 next-page: case-classes
 previous-page: nested-functions
 ---

--- a/tutorials/tour/default-parameter-values.md
+++ b/tutorials/tour/default-parameter-values.md
@@ -5,7 +5,7 @@ title: Default Parameter Values
 disqus: true
 
 tutorial: scala-tour
-num: 32
+num: 33
 next-page: named-parameters
 previous-page: annotations
 ---

--- a/tutorials/tour/explicitly-typed-self-references.md
+++ b/tutorials/tour/explicitly-typed-self-references.md
@@ -5,7 +5,7 @@ title: Explicitly Typed Self References
 disqus: true
 
 tutorial: scala-tour
-num: 24
+num: 25
 next-page: implicit-parameters
 previous-page: compound-types
 ---

--- a/tutorials/tour/extractor-objects.md
+++ b/tutorials/tour/extractor-objects.md
@@ -5,7 +5,7 @@ title: Extractor Objects
 disqus: true
 
 tutorial: scala-tour
-num: 15
+num: 16
 next-page: sequence-comprehensions
 previous-page: regular-expression-patterns
 ---

--- a/tutorials/tour/generic-classes.md
+++ b/tutorials/tour/generic-classes.md
@@ -5,7 +5,7 @@ title: Generic Classes
 disqus: true
 
 tutorial: scala-tour
-num: 17
+num: 18
 next-page: variances
 previous-page: sequence-comprehensions
 ---

--- a/tutorials/tour/higher-order-functions.md
+++ b/tutorials/tour/higher-order-functions.md
@@ -5,7 +5,7 @@ title: Higher-order Functions
 disqus: true
 
 tutorial: scala-tour
-num: 7
+num: 8
 next-page: nested-functions
 previous-page: anonymous-function-syntax
 ---

--- a/tutorials/tour/implicit-conversions.md
+++ b/tutorials/tour/implicit-conversions.md
@@ -5,7 +5,7 @@ title: Implicit Conversions
 disqus: true
 
 tutorial: scala-tour
-num: 26
+num: 27
 next-page: polymorphic-methods
 previous-page: implicit-parameters
 ---

--- a/tutorials/tour/implicit-parameters.md
+++ b/tutorials/tour/implicit-parameters.md
@@ -5,7 +5,7 @@ title: Implicit Parameters
 disqus: true
 
 tutorial: scala-tour
-num: 25
+num: 26
 next-page: implicit-conversions
 previous-page: explicitly-typed-self-references
 ---

--- a/tutorials/tour/inner-classes.md
+++ b/tutorials/tour/inner-classes.md
@@ -5,7 +5,7 @@ title: Inner Classes
 disqus: true
 
 tutorial: scala-tour
-num: 21
+num: 22
 next-page: abstract-types
 previous-page: lower-type-bounds
 ---

--- a/tutorials/tour/local-type-inference.md
+++ b/tutorials/tour/local-type-inference.md
@@ -5,7 +5,7 @@ title: Local Type Inference
 disqus: true
 
 tutorial: scala-tour
-num: 28
+num: 29
 next-page: operators
 previous-page: polymorphic-methods
 ---

--- a/tutorials/tour/lower-type-bounds.md
+++ b/tutorials/tour/lower-type-bounds.md
@@ -5,7 +5,7 @@ title: Lower Type Bounds
 disqus: true
 
 tutorial: scala-tour
-num: 20
+num: 21
 next-page: inner-classes
 previous-page: upper-type-bounds
 ---

--- a/tutorials/tour/mixin-class-composition.md
+++ b/tutorials/tour/mixin-class-composition.md
@@ -5,7 +5,7 @@ title: Mixin Class Composition
 disqus: true
 
 tutorial: scala-tour
-num: 5
+num: 6
 next-page: anonymous-function-syntax
 previous-page: traits
 ---

--- a/tutorials/tour/named-parameters.md
+++ b/tutorials/tour/named-parameters.md
@@ -5,7 +5,7 @@ title: Named Parameters
 disqus: true
 
 tutorial: scala-tour
-num: 33
+num: 34
 previous-page: default-parameter-values
 ---
 

--- a/tutorials/tour/nested-functions.md
+++ b/tutorials/tour/nested-functions.md
@@ -5,7 +5,7 @@ title: Nested Functions
 disqus: true
 
 tutorial: scala-tour
-num: 8
+num: 9
 next-page: currying
 previous-page: higher-order-functions
 ---

--- a/tutorials/tour/operators.md
+++ b/tutorials/tour/operators.md
@@ -5,7 +5,7 @@ title: Operators
 disqus: true
 
 tutorial: scala-tour
-num: 29
+num: 30
 next-page: automatic-closures
 previous-page: local-type-inference
 ---

--- a/tutorials/tour/pattern-matching.md
+++ b/tutorials/tour/pattern-matching.md
@@ -5,7 +5,7 @@ title: Pattern Matching
 disqus: true
 
 tutorial: scala-tour
-num: 11
+num: 12
 
 next-page: singleton-objects
 previous-page: case-classes

--- a/tutorials/tour/polymorphic-methods.md
+++ b/tutorials/tour/polymorphic-methods.md
@@ -5,7 +5,7 @@ title: Polymorphic Methods
 disqus: true
 
 tutorial: scala-tour
-num: 27
+num: 28
 
 next-page: local-type-inference
 previous-page: implicit-conversions

--- a/tutorials/tour/regular-expression-patterns.md
+++ b/tutorials/tour/regular-expression-patterns.md
@@ -5,7 +5,7 @@ title: Regular Expression Patterns
 disqus: true
 
 tutorial: scala-tour
-num: 14
+num: 15
 
 next-page: extractor-objects
 previous-page: xml-processing

--- a/tutorials/tour/sequence-comprehensions.md
+++ b/tutorials/tour/sequence-comprehensions.md
@@ -5,7 +5,7 @@ title: Sequence Comprehensions
 disqus: true
 
 tutorial: scala-tour
-num: 16
+num: 17
 next-page: generic-classes
 previous-page: extractor-objects
 ---

--- a/tutorials/tour/singleton-objects.md
+++ b/tutorials/tour/singleton-objects.md
@@ -5,7 +5,7 @@ title: Singleton Objects
 disqus: true
 
 tutorial: scala-tour
-num: 12
+num: 13
 
 next-page: xml-processing
 previous-page: pattern-matching

--- a/tutorials/tour/tour-of-scala.md
+++ b/tutorials/tour/tour-of-scala.md
@@ -7,8 +7,8 @@ disqus: true
 tutorial: scala-tour
 num: 1
 languages: [ba, es, ko, pt-br]
-outof: 33
-next-page: unified-types
+outof: 34
+next-page: basics
 ---
 
 Scala is a modern multi-paradigm programming language designed to express common programming patterns in a concise, elegant, and type-safe way. It smoothly integrates features of object-oriented and functional languages.

--- a/tutorials/tour/traits.md
+++ b/tutorials/tour/traits.md
@@ -5,7 +5,7 @@ title: Traits
 disqus: true
 
 tutorial: scala-tour
-num: 4
+num: 5
 next-page: mixin-class-composition
 previous-page: classes
 ---

--- a/tutorials/tour/unified-types.md
+++ b/tutorials/tour/unified-types.md
@@ -5,9 +5,9 @@ title: Unified Types
 disqus: true
 
 tutorial: scala-tour
-num: 2
+num: 3
 next-page: classes
-previous-page: tour-of-scala
+previous-page: basics
 ---
 
 In contrast to Java, all values in Scala are objects (including numerical values and functions). Since Scala is class-based, all values are instances of a class. The diagram below illustrates the class hierarchy.

--- a/tutorials/tour/upper-type-bounds.md
+++ b/tutorials/tour/upper-type-bounds.md
@@ -5,7 +5,7 @@ title: Upper Type Bounds
 disqus: true
 
 tutorial: scala-tour
-num: 19
+num: 20
 next-page: lower-type-bounds
 previous-page: variances
 ---

--- a/tutorials/tour/variances.md
+++ b/tutorials/tour/variances.md
@@ -5,7 +5,7 @@ title: Variances
 disqus: true
 
 tutorial: scala-tour
-num: 18
+num: 19
 next-page: upper-type-bounds
 previous-page: generic-classes
 ---

--- a/tutorials/tour/xml-processing.md
+++ b/tutorials/tour/xml-processing.md
@@ -5,7 +5,7 @@ title: XML Processing
 disqus: true
 
 tutorial: scala-tour
-num: 13
+num: 14
 next-page: regular-expression-patterns
 previous-page: singleton-objects
 ---


### PR DESCRIPTION
I believe majority of people coming to tutorials are more interested in quick examples than detailed explanations.

The current first real tutorial is Unified Types. While it's helpful to know that information, it doesn't give you much insight into how Scala code would look like. I think it can lose interest of readers.

Also, while many pages are using features like `object`, `App`, `var`, `val`, etc, what they are isn't necessarily clearly communicated before it's introduced. I think it can throw out readers.

I created a Basics page to address those concerns. The page is supposed to provide just the most important information out of the most important topics.

Personally, for this kind of tutorial, I think it makes more sense to use REPL because it will be easier for writers to make sure what they provide is completely reproducible on reader's machine, and it will be more interesting to readers because it will be easier to interact and play with the code. While I didn't do it because it will be a bigger change if you consider consistency, I think it's worth considering.

Another option is to give them link to the [ScalaFiddle](https://scalafiddle.io) so that we can achieve the same goal without readers installing anything on their machine.

I tried to test it locally, but I am having trouble setting up the build environment (`bundle install` fails because `gem install json -v '1.8.3'` fails, tried multiple solutions found online, and eventually gave up), so I haven't tested it yet, but it looks fine on GitHub.