### PR TITLE
Fix pt-br Tour of Scala

### DIFF
--- a/pl/tutorials/tour/_posts/2017-02-13-abstract-types.md
+++ b/pl/tutorials/tour/_posts/2017-02-13-abstract-types.md
@@ -7,7 +7,6 @@ disqus: true
 tutorial: scala-tour
 categories: tour
 num: 22
-languages: [ba, es, ko, pl]
 language: pl
 tutorial-next: compound-types
 tutorial-previous: inner-classes


### PR DESCRIPTION
Makes pt-br translation show up in Tour of Scala ToC which became broken in #684.