### PR TITLE
variances-page: use T and S instead of A and B

### DIFF
--- a/ba/tutorials/tour/_posts/2017-02-13-variances.md
+++ b/ba/tutorials/tour/_posts/2017-02-13-variances.md
@@ -23,24 +23,26 @@ Molimo primijetite da je ovo komplikovaniji primjer koji kombinuje upotrebu [pol
 [donjih granica tipa](lower-type-bounds.html), i kovarijantnu anotaciju tipskog parametra na netrivijalan način. 
 Nadalje, koristimo [unutarnje klase](inner-classes.html) da povežemo elemente steka bez eksplicitnih veza.
 
-    class Stack[+A] {
-      def push[B >: A](elem: B): Stack[B] = new Stack[B] {
-        override def top: B = elem
-        override def pop: Stack[B] = Stack.this
-        override def toString() = elem.toString() + " " +
-                                  Stack.this.toString()
-      }
-      def top: A = sys.error("no element on stack")
-      def pop: Stack[A] = sys.error("no element on stack")
-      override def toString() = ""
-    }
-    
-    object VariancesTest extends App {
-      var s: Stack[Any] = new Stack().push("hello");
-      s = s.push(new Object())
-      s = s.push(7)
-      println(s)
-    }
+```tut
+class Stack[+T] {
+  def push[S >: T](elem: S): Stack[S] = new Stack[S] {
+    override def top: S = elem
+    override def pop: Stack[S] = Stack.this
+    override def toString: String =
+      elem.toString + " " + Stack.this.toString
+  }
+  def top: T = sys.error("no element on stack")
+  def pop: Stack[T] = sys.error("no element on stack")
+  override def toString: String = ""
+}
+
+object VariancesTest extends App {
+  var s: Stack[Any] = new Stack().push("hello")
+  s = s.push(new Object())
+  s = s.push(7)
+  println(s)
+}
+```
 
 Anotacija `+T` deklariše tip `T` da bude korišten samo na kovarijantnim pozicijama.
 Slično, `-T` bi deklarisalo `T` da bude korišten samo na kontravarijantnim pozicijama.

--- a/es/tutorials/tour/_posts/2017-02-13-variances.md
+++ b/es/tutorials/tour/_posts/2017-02-13-variances.md
@@ -14,24 +14,26 @@ Scala soporta anotaciones de varianza para parámetros de tipo para [clases gen�
 
 En el artículo sobre clases genéricas dimos un ejemplo de una pila mutable. Explicamos que el tipo definido por la clase `Stack[T]` es objeto de subtipos invariantes con respecto al parámetro de tipo. Esto puede restringir el reuso de la abstracción (la clase). Ahora derivaremos una implementación funcional (es decir, inmutable) para pilas que no tienen esta restricción. Nótese que este es un ejemplo avanzado que combina el uso de [métodos polimórficos](polymorphic-methods.html), [límites de tipado inferiores](lower-type-bounds.html), y anotaciones de parámetros de tipo covariante de una forma no trivial. Además hacemos uso de [clases internas](inner-classes.html) para encadenar los elementos de la pila sin enlaces explícitos.
 
-    class Stack[+A] {
-      def push[B >: A](elem: B): Stack[B] = new Stack[B] {
-        override def top: B = elem
-        override def pop: Stack[B] = Stack.this
-        override def toString() = elem.toString() + " " +
-                                  Stack.this.toString()
-      }
-      def top: A = sys.error("no element on stack")
-      def pop: Stack[A] = sys.error("no element on stack")
-      override def toString() = ""
-    }
-    
-    object VariancesTest extends App {
-      var s: Stack[Any] = new Stack().push("hello");
-      s = s.push(new Object())
-      s = s.push(7)
-      println(s)
-    }
+```tut
+class Stack[+T] {
+  def push[S >: T](elem: S): Stack[S] = new Stack[S] {
+    override def top: S = elem
+    override def pop: Stack[S] = Stack.this
+    override def toString: String =
+      elem.toString + " " + Stack.this.toString
+  }
+  def top: T = sys.error("no element on stack")
+  def pop: Stack[T] = sys.error("no element on stack")
+  override def toString: String = ""
+}
+
+object VariancesTest extends App {
+  var s: Stack[Any] = new Stack().push("hello")
+  s = s.push(new Object())
+  s = s.push(7)
+  println(s)
+}
+```
 
 La anotación `+T` declara que el tipo `T` sea utilizado solamente en posiciones covariantes. De forma similar, `-T` declara que `T` sea usado en posiciones contravariantes. Para parámetros de tipo covariantes obtenemos una relación de subtipo covariante con respecto al parámetro de tipo. Para nuestro ejemplo, esto significa que `Stack[T]` es un subtipo de `Stack[S]` si `T` es un subtipo de `S`. Lo contrario se cumple para parámetros de tipo que son etiquetados con un signo `-`.
 

--- a/ko/tutorials/tour/_posts/2017-02-13-variances.md
+++ b/ko/tutorials/tour/_posts/2017-02-13-variances.md
@@ -14,24 +14,26 @@ language: ko
 
 [제네릭 클래스](generic-classes.html)에 관한 페이지에선 변경 가능한 스택의 예제를 살펴보면서, 클래스 `Stack[T]`에서 정의한 타입은 타입 파라미터의 서브타입이 불변자여야 함을 설명했었다. 이는 추상화된 클래스의 재사용을 제한할 수 있다. 지금부턴 이런 제약이 없는 함수형(즉, 변경이 불가능한) 스택의 구현을 알아본다. 이 구현은 [다형성 메소드](polymorphic-methods.html), [하위 타입 경계](lower-type-bounds.html), 순가변 타입 파라미터 어노테이션 등의 중요 개념을 조합한 좀 더 어려운 예제임을 알아두자. 또한 [내부 클래스](inner-classes.html)를 사용해 명시적인 연결 없이도 스택의 항목을 서로 묶을 수 있도록 만들었다.
 
-    class Stack[+A] {
-      def push[B >: A](elem: B): Stack[B] = new Stack[B] {
-        override def top: B = elem
-        override def pop: Stack[B] = Stack.this
-        override def toString() = elem.toString() + " " +
-                                  Stack.this.toString()
-      }
-      def top: A = sys.error("no element on stack")
-      def pop: Stack[A] = sys.error("no element on stack")
-      override def toString() = ""
-    }
-    
-    object VariancesTest extends App {
-      var s: Stack[Any] = new Stack().push("hello");
-      s = s.push(new Object())
-      s = s.push(7)
-      println(s)
-    }
+```tut
+class Stack[+T] {
+  def push[S >: T](elem: S): Stack[S] = new Stack[S] {
+    override def top: S = elem
+    override def pop: Stack[S] = Stack.this
+    override def toString: String =
+      elem.toString + " " + Stack.this.toString
+  }
+  def top: T = sys.error("no element on stack")
+  def pop: Stack[T] = sys.error("no element on stack")
+  override def toString: String = ""
+}
+
+object VariancesTest extends App {
+  var s: Stack[Any] = new Stack().push("hello")
+  s = s.push(new Object())
+  s = s.push(7)
+  println(s)
+}
+```
 
 어노테이션 `+T`는 타입 순가변 위치에서만 사용할 수 있는 타입 `T`를 선언한다. 이와 유사하게, `-T`는 역가변 위치에서만 사용할 수 있는 `T`를 선언한다. 순가변 타입 파라미터의 경우, 타입 파라미터의 정의에 따라 서브타입과 순가변 관계를 형성한다. 즉, `T`가 `S`의 서브타입이라면 이 예제의 `Stack[T]`는 `Stack[S]`의 서브타입이다. `-`로 표시된 타입 파라미터 사이에는 이와는 반대의 관계가 맺어진다.
 

--- a/pl/tutorials/tour/_posts/2017-02-13-variances.md
+++ b/pl/tutorials/tour/_posts/2017-02-13-variances.md
@@ -17,20 +17,20 @@ Scala wspiera adnotacje wariancji parametrów typów [klas generycznych](generic
 Na stronie o [klasach generycznych](generic-classes.html) omówiliśmy przykład zmiennego stosu. Wyjaśniliśmy, że typ definiowany przez klasę `Stack[T]` jest poddany niezmiennemu podtypowaniu w stosunku do parametru typu. Może to ograniczyć możliwość ponownego wykorzystania abstrakcji tej klasy. Spróbujemy teraz opracować funkcyjną (tzn. niemutowalną) implementację dla stosów, które nie posiadają tego ograniczenia. Warto zwrócić uwagę, że jest to zaawansowany przykład łączący w sobie zastosowanie [funkcji polimorficznych](polymorphic-methods.html), [dolnych ograniczeń typu](lower-type-bounds.html) oraz kowariantnych adnotacji parametru typu. Dodatkowo stosujemy też [klasy wewnętrzne](inner-classes.html), aby połączyć ze sobą elementy stosu bez jawnych powiązań.
 
 ```tut
-class Stack[+A] {
-  def push[B >: A](elem: B): Stack[B] = new Stack[B] {
-    override def top: B = elem
-    override def pop: Stack[B] = Stack.this
-    override def toString() = elem.toString() + " " +
-                              Stack.this.toString()
+class Stack[+T] {
+  def push[S >: T](elem: S): Stack[S] = new Stack[S] {
+    override def top: S = elem
+    override def pop: Stack[S] = Stack.this
+    override def toString: String =
+      elem.toString + " " + Stack.this.toString
   }
-  def top: A = sys.error("no element on stack")
-  def pop: Stack[A] = sys.error("no element on stack")
-  override def toString() = ""
+  def top: T = sys.error("no element on stack")
+  def pop: Stack[T] = sys.error("no element on stack")
+  override def toString: String = ""
 }
 
 object VariancesTest extends App {
-  var s: Stack[Any] = new Stack().push("hello");
+  var s: Stack[Any] = new Stack().push("hello")
   s = s.push(new Object())
   s = s.push(7)
   println(s)

--- a/pt-br/tutorials/tour/_posts/2017-02-13-variances.md
+++ b/pt-br/tutorials/tour/_posts/2017-02-13-variances.md
@@ -17,20 +17,20 @@ Scala suporta anotações de variância de parâmetros de tipo de [classes gené
 Na página sobre [classes genéricas](generic-classes.html) foi dado um exemplo de uma pilha de estado mutável. Explicamos que o tipo definido pela classe `Stack [T]` está sujeito a subtipos invariantes em relação ao parâmetro de tipo. Isso pode restringir a reutilização da abstração de classe. Derivamos agora uma implementação funcional (isto é, imutável) para pilhas que não tem esta restrição. Por favor, note que este é um exemplo avançado que combina o uso de [métodos polimórficos](polymorphic-methods.html), [limites de tipo inferiores](lower-type-bounds.html) e anotações de parâmetros de tipos covariantes em um estilo não trivial. Além disso, fazemos uso de [classes internas](inner-classes.html) para encadear os elementos da pilha sem links explícitos.
 
 ```tut
-class Stack[+A] {
-  def push[B >: A](elem: B): Stack[B] = new Stack[B] {
-    override def top: B = elem
-    override def pop: Stack[B] = Stack.this
-    override def toString() = elem.toString() + " " +
-                              Stack.this.toString()
+class Stack[+T] {
+  def push[S >: T](elem: S): Stack[S] = new Stack[S] {
+    override def top: S = elem
+    override def pop: Stack[S] = Stack.this
+    override def toString: String =
+      elem.toString + " " + Stack.this.toString
   }
-  def top: A = sys.error("no element on stack")
-  def pop: Stack[A] = sys.error("no element on stack")
-  override def toString() = ""
+  def top: T = sys.error("no element on stack")
+  def pop: Stack[T] = sys.error("no element on stack")
+  override def toString: String = ""
 }
 
 object VariancesTest extends App {
-  var s: Stack[Any] = new Stack().push("hello");
+  var s: Stack[Any] = new Stack().push("hello")
   s = s.push(new Object())
   s = s.push(7)
   println(s)

--- a/tutorials/tour/_posts/2017-02-13-variances.md
+++ b/tutorials/tour/_posts/2017-02-13-variances.md
@@ -15,20 +15,20 @@ Scala supports variance annotations of type parameters of [generic classes](gene
 In the page about [generic classes](generic-classes.html) an example for a mutable stack was given. We explained that the type defined by the class `Stack[T]` is subject to invariant subtyping regarding the type parameter. This can restrict the reuse of the class abstraction. We now derive a functional (i.e. immutable) implementation for stacks which does not have this restriction. Please note that this is an advanced example which combines the use of [polymorphic methods](polymorphic-methods.html), [lower type bounds](lower-type-bounds.html), and covariant type parameter annotations in a non-trivial fashion. Furthermore we make use of [inner classes](inner-classes.html) to chain the stack elements without explicit links.
 
 ```tut
-class Stack[+A] {
-  def push[B >: A](elem: B): Stack[B] = new Stack[B] {
-    override def top: B = elem
-    override def pop: Stack[B] = Stack.this
-    override def toString() = elem.toString() + " " +
-                              Stack.this.toString()
+class Stack[+T] {
+  def push[S >: T](elem: S): Stack[S] = new Stack[S] {
+    override def top: S = elem
+    override def pop: Stack[S] = Stack.this
+    override def toString: String =
+      elem.toString + " " + Stack.this.toString
   }
-  def top: A = sys.error("no element on stack")
-  def pop: Stack[A] = sys.error("no element on stack")
-  override def toString() = ""
+  def top: T = sys.error("no element on stack")
+  def pop: Stack[T] = sys.error("no element on stack")
+  override def toString: String = ""
 }
 
 object VariancesTest extends App {
-  var s: Stack[Any] = new Stack().push("hello");
+  var s: Stack[Any] = new Stack().push("hello")
   s = s.push(new Object())
   s = s.push(7)
   println(s)


### PR DESCRIPTION
like in the description and some styling fixes

mentioned in the comments of http://docs.scala-lang.org/tutorials/tour/variances.html