### PR TITLE
Removed duplicated instead

### DIFF
--- a/tutorials/tour/_posts/2017-02-13-singleton-objects.md
+++ b/tutorials/tour/_posts/2017-02-13-singleton-objects.md
@@ -51,7 +51,7 @@ It's common to see typeclass instances as [implicit values](implicit-parameters.
 
 ## Notes for Java programmers ##
 
-`static` is not a keyword in Scala. Instead, all members that would be static, including classes, should go in a singleton object instead. They can be referred to with the same syntax, imported piecemeal or as a group, and so on.
+`static` is not a keyword in Scala. Instead, all members that would be static, including classes, should go in a singleton object. They can be referred to with the same syntax, imported piecemeal or as a group, and so on.
 
 Frequently, Java programmers define static members, perhaps `private`, as implementation aids for their instance members. These move to the companion, too; a common pattern is to import the companion object's members in the class, like so:
 


### PR DESCRIPTION
The word `instead` is used twice in the same sentence on http://docs.scala-lang.org/tutorials/tour/singleton-objects.html, it sounds unnatural.