### PR TITLE
Fix formatting of code snippets in Future docs

### DIFF
--- a/overviews/core/_posts/2012-09-20-futures.md
+++ b/overviews/core/_posts/2012-09-20-futures.md
@@ -121,7 +121,7 @@ As explained in the `ForkJoinPool` API, this is only possible if the pool is exp
 Fortunately the concurrent package provides a convenient way for doing so:
 
     import scala.concurrent.Future
-	  import scala.concurrent.blocking
+    import scala.concurrent.blocking
 
     Future {
       blocking {
@@ -165,16 +165,16 @@ One might be tempted to have an `ExecutionContext` that runs computations within
 
     val currentThreadExecutionContext = ExecutionContext.fromExecutor(
       new Executor {
-      	// Do not do this!
+        // Do not do this!
         def execute(runnable: Runnable) { runnable.run() }
     })
 
 This should be avoided as it introduces non-determinism in the execution of your future.
 
     Future {
-    	doSomething
-   	}(ExecutionContext.global).map {
-    	doSomethingElse
+      doSomething
+    }(ExecutionContext.global).map {
+      doSomethingElse
     }(currentThreadExecutionContext)
 
 The `doSomethingElse` call might either execute in `doSomething`'s thread or in the main thread, and therefore be either asynchronous or synchronous.


### PR DESCRIPTION
Replaced some rogue tabs with appropriate spaces to fix the formatting of some snippets on http://docs.scala-lang.org/overviews/core/futures.html