### PR TITLE
Refer to 'by-name-parameters' page instead of non-existing page

### DIFF
--- a/tutorials/tour/_posts/2017-02-13-annotations.md
+++ b/tutorials/tour/_posts/2017-02-13-annotations.md
@@ -8,7 +8,7 @@ tutorial: scala-tour
 categories: tour
 num: 32
 next-page: default-parameter-values
-previous-page: automatic-closures
+previous-page: by-name-parameters
 ---
 
 Annotations associate meta-information with definitions. For example, the annotation `@deprecated` before a method causes the compiler to print a warning if the method is used.

--- a/tutorials/tour/_posts/2017-02-13-operators.md
+++ b/tutorials/tour/_posts/2017-02-13-operators.md
@@ -7,7 +7,7 @@ discourse: true
 tutorial: scala-tour
 categories: tour
 num: 30
-next-page: automatic-closures
+next-page: by-name-parameters
 previous-page: local-type-inference
 prerequisite-knowledge: case-classes
 ---


### PR DESCRIPTION
Refer to 'by-name-parameters' page instead of non-existing 'automatic-closures' page