### PR TITLE
Fixed next/previous links in tutorials/tour docs

### DIFF
--- a/ba/tutorials/tour/_posts/2017-02-13-abstract-types.md
+++ b/ba/tutorials/tour/_posts/2017-02-13-abstract-types.md
@@ -9,6 +9,9 @@ categories: tour
 num: 22
 outof: 33
 language: ba
+
+next-page: compound-types
+previous-page: inner-classes
 ---
 
 U Scali, klase su parameterizovane vrijednostima (parameteri konstruktora) i tipovima (ako su [generičke](generic-classes.html)).

--- a/ba/tutorials/tour/_posts/2017-02-13-annotations.md
+++ b/ba/tutorials/tour/_posts/2017-02-13-annotations.md
@@ -9,6 +9,9 @@ categories: tour
 num: 31
 outof: 33
 language: ba
+
+next-page: default-parameter-values
+previous-page: case-classes
 ---
 
 Anotacije pridružuju meta-informacije definicijama.

--- a/ba/tutorials/tour/_posts/2017-02-13-anonymous-function-syntax.md
+++ b/ba/tutorials/tour/_posts/2017-02-13-anonymous-function-syntax.md
@@ -9,6 +9,9 @@ categories: tour
 num: 6
 outof: 33
 language: ba
+
+next-page: higher-order-functions
+previous-page: mixin-class-composition
 ---
 
 Scala omogućuje relativno lahku sintaksu za definisanje anonimnih funkcija. Sljedeći izraz kreira funkciju za sljedbenike cijelih brojeva:

--- a/ba/tutorials/tour/_posts/2017-02-13-automatic-closures.md
+++ b/ba/tutorials/tour/_posts/2017-02-13-automatic-closures.md
@@ -9,6 +9,9 @@ categories: tour
 num: 30
 outof: 33
 language: ba
+
+next-page: case-classes
+previous-page: operators
 ---
 
 Scala dozvoljava da se argument (ili više njih) metode ne evaluira prije samog poziva metode.

--- a/ba/tutorials/tour/_posts/2017-02-13-case-classes.md
+++ b/ba/tutorials/tour/_posts/2017-02-13-case-classes.md
@@ -9,6 +9,9 @@ categories: tour
 num: 30
 outof: 33
 language: ba
+
+next-page: annotations
+previous-page: automatic-closures
 ---
 
 Scala podržava tzv. _case klase_.

--- a/ba/tutorials/tour/_posts/2017-02-13-classes.md
+++ b/ba/tutorials/tour/_posts/2017-02-13-classes.md
@@ -9,6 +9,9 @@ categories: tour
 num: 3
 outof: 33
 language: ba
+
+next-page: traits
+previous-page: unified-types
 ---
 
 Klase u Scali su statički šabloni koji mogu biti instancirani u više objekata tokom izvršavanja programa (runtime).

--- a/ba/tutorials/tour/_posts/2017-02-13-compound-types.md
+++ b/ba/tutorials/tour/_posts/2017-02-13-compound-types.md
@@ -9,6 +9,9 @@ categories: tour
 num: 23
 outof: 33
 language: ba
+
+next-page: explicitly-typed-self-references
+previous-page: abstract-types
 ---
 
 Ponekad je potrebno izraziti da je tip objekta podtip nekoliko drugih tipova. 

--- a/ba/tutorials/tour/_posts/2017-02-13-currying.md
+++ b/ba/tutorials/tour/_posts/2017-02-13-currying.md
@@ -9,6 +9,9 @@ categories: tour
 num: 9
 outof: 33
 language: ba
+
+next-page: pattern-matching
+previous-page: nested-functions
 ---
 
 Metode mogu definisati više lista parametara. 

--- a/ba/tutorials/tour/_posts/2017-02-13-default-parameter-values.md
+++ b/ba/tutorials/tour/_posts/2017-02-13-default-parameter-values.md
@@ -9,6 +9,9 @@ categories: tour
 num: 32
 outof: 33
 language: ba
+
+next-page: named-parameters
+previous-page: annotations
 ---
 
 Scala omogućuje davanje podrazumijevanih vrijednosti parametrima koje dozvoljavaju korisniku metode da izostavi te parametre.

--- a/ba/tutorials/tour/_posts/2017-02-13-explicitly-typed-self-references.md
+++ b/ba/tutorials/tour/_posts/2017-02-13-explicitly-typed-self-references.md
@@ -9,6 +9,9 @@ categories: tour
 num: 24
 outof: 33
 language: ba
+
+next-page: implicit-parameters
+previous-page: compound-types
 ---
 
 Kada se razvija proširiv softver ponekad je zgodno deklarisati tip vrijednosti `this` eksplicitno.  

--- a/ba/tutorials/tour/_posts/2017-02-13-extractor-objects.md
+++ b/ba/tutorials/tour/_posts/2017-02-13-extractor-objects.md
@@ -9,6 +9,9 @@ categories: tour
 num: 15
 outof: 33
 language: ba
+
+next-page: sequence-comprehensions
+previous-page: regular-expression-patterns
 ---
 
 U Scali, uzorci (patterns) mogu biti definisani nezavisno od case klasa.

--- a/ba/tutorials/tour/_posts/2017-02-13-generic-classes.md
+++ b/ba/tutorials/tour/_posts/2017-02-13-generic-classes.md
@@ -9,6 +9,9 @@ categories: tour
 num: 17
 outof: 33
 language: ba
+
+next-page: variances
+previous-page: sequence-comprehensions
 ---
 
 Kao u Javi 5 ([JDK 1.5](http://java.sun.com/j2se/1.5/)), Scala ima ugrađenu podršku za klase parametrizovane tipovima.

--- a/ba/tutorials/tour/_posts/2017-02-13-higher-order-functions.md
+++ b/ba/tutorials/tour/_posts/2017-02-13-higher-order-functions.md
@@ -9,6 +9,9 @@ categories: tour
 num: 7
 outof: 33
 language: ba
+
+next-page: nested-functions
+previous-page: anonymous-function-syntax
 ---
 
 Scala dozvoljava definisanje funkcija višeg reda.

--- a/ba/tutorials/tour/_posts/2017-02-13-implicit-conversions.md
+++ b/ba/tutorials/tour/_posts/2017-02-13-implicit-conversions.md
@@ -9,6 +9,9 @@ categories: tour
 num: 26
 outof: 33
 language: ba
+
+next-page: polymorphic-methods
+previous-page: implicit-parameters
 ---
 
 Implicitna konverzija iz tipa `S` u tip `T` je definisana kao implicitna vrijednost koja ima tip `S => T` (funkcija), 

--- a/ba/tutorials/tour/_posts/2017-02-13-implicit-parameters.md
+++ b/ba/tutorials/tour/_posts/2017-02-13-implicit-parameters.md
@@ -9,6 +9,9 @@ categories: tour
 num: 25
 outof: 33
 language: ba
+
+next-page: implicit-conversions
+previous-page: explicitly-typed-self-references
 ---
 
 Metoda s _implicitnim parametrima_ može biti primijenjena na argumente kao i normalna metoda.

--- a/ba/tutorials/tour/_posts/2017-02-13-inner-classes.md
+++ b/ba/tutorials/tour/_posts/2017-02-13-inner-classes.md
@@ -9,6 +9,9 @@ categories: tour
 num: 21
 outof: 33
 language: ba
+
+next-page: abstract-types
+previous-page: lower-type-bounds
 ---
 
 U Scali je moguće da klase imaju druge klase kao članove.

--- a/ba/tutorials/tour/_posts/2017-02-13-local-type-inference.md
+++ b/ba/tutorials/tour/_posts/2017-02-13-local-type-inference.md
@@ -9,6 +9,9 @@ categories: tour
 num: 28
 outof: 33
 language: ba
+
+next-page: operators
+previous-page: polymorphic-methods
 ---
 Scala ima ugrađen mehanizam zaključivanja tipova koji dozvoljava programeru da izostavi određene anotacije tipova.
 Često nije potrebno specificirati tip varijable u Scali,

--- a/ba/tutorials/tour/_posts/2017-02-13-lower-type-bounds.md
+++ b/ba/tutorials/tour/_posts/2017-02-13-lower-type-bounds.md
@@ -9,6 +9,9 @@ categories: tour
 num: 20
 outof: 33
 language: ba
+
+next-page: inner-classes
+previous-page: upper-type-bounds
 ---
 
 Dok [gornja granica tipa](upper-type-bounds.html) limitira tip na podtip nekog drugog tipa,

--- a/ba/tutorials/tour/_posts/2017-02-13-mixin-class-composition.md
+++ b/ba/tutorials/tour/_posts/2017-02-13-mixin-class-composition.md
@@ -9,6 +9,9 @@ categories: tour
 num: 5
 outof: 33
 language: ba
+
+next-page: anonymous-function-syntax
+previous-page: traits
 ---
 
 Nasuprot jezicima koji podržavaju samo _jednostruko nasljeđivanje_, Scala ima generalniji pojam ponovne upotrebe klasa.

--- a/ba/tutorials/tour/_posts/2017-02-13-named-parameters.md
+++ b/ba/tutorials/tour/_posts/2017-02-13-named-parameters.md
@@ -9,6 +9,8 @@ categories: tour
 num: 33
 outof: 33
 language: ba
+
+previous-page: default-parameter-values
 ---
 
 Kada se pozivaju metode i funkcije, možete koristiti imena varijabli eksplicitno pri pozivu:

--- a/ba/tutorials/tour/_posts/2017-02-13-nested-functions.md
+++ b/ba/tutorials/tour/_posts/2017-02-13-nested-functions.md
@@ -9,6 +9,9 @@ categories: tour
 num: 8
 outof: 33
 language: ba
+
+next-page: currying
+previous-page: higher-order-functions
 ---
 
 U Scali je moguće ugnježdavati definicije funkcija.

--- a/ba/tutorials/tour/_posts/2017-02-13-operators.md
+++ b/ba/tutorials/tour/_posts/2017-02-13-operators.md
@@ -9,6 +9,9 @@ categories: tour
 num: 29
 outof: 33
 language: ba
+
+next-page: automatic-closures
+previous-page: local-type-inference
 ---
 
 Bilo koja metoda koja prima samo jedan parametar može biti korištena kao *infiksni operator* u Scali.

--- a/ba/tutorials/tour/_posts/2017-02-13-pattern-matching.md
+++ b/ba/tutorials/tour/_posts/2017-02-13-pattern-matching.md
@@ -10,6 +10,9 @@ num: 11
 
 outof: 33
 language: ba
+
+next-page: singleton-objects
+previous-page: currying
 ---
 
 Scala ima ugrađen mehanizam generalnog podudaranja uzoraka.

--- a/ba/tutorials/tour/_posts/2017-02-13-polymorphic-methods.md
+++ b/ba/tutorials/tour/_posts/2017-02-13-polymorphic-methods.md
@@ -10,6 +10,9 @@ num: 27
 
 outof: 33
 language: ba
+
+next-page: local-type-inference
+previous-page: implicit-conversions
 ---
 
 Metode u Scali mogu biti parametrizovane i s vrijednostima i s tipovima.

--- a/ba/tutorials/tour/_posts/2017-02-13-regular-expression-patterns.md
+++ b/ba/tutorials/tour/_posts/2017-02-13-regular-expression-patterns.md
@@ -10,6 +10,9 @@ num: 14
 
 outof: 33
 language: ba
+
+next-page: extractor-objects
+previous-page: singleton-objects
 ---
 
 ## Desno-ignorišući uzorci sekvenci ##

--- a/ba/tutorials/tour/_posts/2017-02-13-sequence-comprehensions.md
+++ b/ba/tutorials/tour/_posts/2017-02-13-sequence-comprehensions.md
@@ -9,6 +9,9 @@ categories: tour
 num: 16
 outof: 33
 language: ba
+
+next-page: generic-classes
+previous-page: extractor-objects
 ---
 
 Scala ima skraćenu notaciju za pisanje *komprehensija sekvenci*.

--- a/ba/tutorials/tour/_posts/2017-02-13-singleton-objects.md
+++ b/ba/tutorials/tour/_posts/2017-02-13-singleton-objects.md
@@ -10,6 +10,9 @@ num: 12
 
 outof: 33
 language: ba
+
+next-page: regular-expression-patterns
+previous-page: pattern-matching
 ---
 
 Metode i vrijednosti koje ne pripadaju individualnim instancama [klase](classes.html) pripadaju *singlton objektima*,

--- a/ba/tutorials/tour/_posts/2017-02-13-tour-of-scala.md
+++ b/ba/tutorials/tour/_posts/2017-02-13-tour-of-scala.md
@@ -9,6 +9,8 @@ categories: tour
 num: 1
 outof: 33
 language: ba
+
+next-page: unified-types
 ---
 
 Scala je moderan programski jezik koji spaja više paradigmi,

--- a/ba/tutorials/tour/_posts/2017-02-13-traits.md
+++ b/ba/tutorials/tour/_posts/2017-02-13-traits.md
@@ -9,6 +9,9 @@ categories: tour
 num: 4
 outof: 33
 language: ba
+
+next-page: mixin-class-composition
+previous-page: classes
 ---
 
 Slično Javinim interfejsima, trejtovi se koriste za definisanje tipova objekata navođenjem potpisa podržanih metoda.

--- a/ba/tutorials/tour/_posts/2017-02-13-unified-types.md
+++ b/ba/tutorials/tour/_posts/2017-02-13-unified-types.md
@@ -9,6 +9,9 @@ categories: tour
 num: 2
 outof: 33
 language: ba
+
+next-page: classes
+previous-page: tour-of-scala
 ---
 
 Nasuprot Javi, sve vrijednosti u Scali su objekti (uključujući brojeve i funkcije).

--- a/ba/tutorials/tour/_posts/2017-02-13-upper-type-bounds.md
+++ b/ba/tutorials/tour/_posts/2017-02-13-upper-type-bounds.md
@@ -9,6 +9,9 @@ categories: tour
 num: 19
 outof: 33
 language: ba
+
+next-page: lower-type-bounds
+previous-page: variances
 ---
 
 U Scali, [tipski parametri](generic-classes.html) i [apstraktni tipovi](abstract-types.html) mogu biti ograničeni granicom tipa.

--- a/ba/tutorials/tour/_posts/2017-02-13-variances.md
+++ b/ba/tutorials/tour/_posts/2017-02-13-variances.md
@@ -9,6 +9,9 @@ categories: tour
 num: 18
 outof: 33
 language: ba
+
+next-page: upper-type-bounds
+previous-page: generic-classes
 ---
 
 Scala podržava anotacije varijanse tipskih parametara [generičkih klasa](generic-classes.html).

--- a/es/tutorials/tour/_posts/2017-02-13-abstract-types.md
+++ b/es/tutorials/tour/_posts/2017-02-13-abstract-types.md
@@ -9,6 +9,9 @@ categories: tour
 num: 2
 outof: 33
 language: es
+
+next-page: annotations
+previous-page: tour-of-scala
 ---
 
 En Scala, las cases son parametrizadas con valores (los parámetros de construcción) y con tipos (si las clases son [genéricas](generic-classes.html)). Por razones de consistencia, no es posible tener solo valores como miembros de objetos; tanto los tipos como los valores son miembros de objetos. Además, ambos tipos de miembros pueden ser concretos y abstractos.

--- a/es/tutorials/tour/_posts/2017-02-13-annotations.md
+++ b/es/tutorials/tour/_posts/2017-02-13-annotations.md
@@ -8,6 +8,9 @@ tutorial: scala-tour
 categories: tour
 num: 3
 language: es
+
+next-page: classes
+previous-page: abstract-types
 ---
 
 Las anotaciones sirven para asociar meta-información con definiciones.

--- a/es/tutorials/tour/_posts/2017-02-13-anonymous-function-syntax.md
+++ b/es/tutorials/tour/_posts/2017-02-13-anonymous-function-syntax.md
@@ -8,6 +8,9 @@ tutorial: scala-tour
 categories: tour
 num: 14
 language: es
+
+next-page: currying
+previous-page: nested-functions
 ---
 
 Scala provee una sintaxis relativamente livana para definir funciones anónimas. La siguiente expresión crea una función incrementadora para números enteros:

--- a/es/tutorials/tour/_posts/2017-02-13-automatic-closures.md
+++ b/es/tutorials/tour/_posts/2017-02-13-automatic-closures.md
@@ -8,6 +8,9 @@ tutorial: scala-tour
 categories: tour
 num: 16
 language: es
+
+next-page: operators
+previous-page: currying
 ---
 
 Scala permite pasar funciones sin parámetros como parámetros de un método. Cuando un método así es invocado, los parámetros reales de la función enviada sin parámetros no son evaluados y una función "nularia" (de aridad cero, 0-aria, o sin parámetros) es pasada en su lugar. Esta función encapsula el comportamiento del parámetro correspondiente (comunmente conocido como "llamada por nombre").

--- a/es/tutorials/tour/_posts/2017-02-13-case-classes.md
+++ b/es/tutorials/tour/_posts/2017-02-13-case-classes.md
@@ -8,6 +8,9 @@ tutorial: scala-tour
 categories: tour
 num: 5
 language: es
+
+next-page: compound-types
+previous-page: classes
 ---
 
 Scala da soporte a la noción de _clases caso_ (en inglés _case classes_, desde ahora _clases Case_). Las clases Case son clases regulares las cuales exportan sus parámetros constructores y a su vez proveen una descomposición recursiva de sí mismas a través de [reconocimiento de patrones](pattern-matching.html).

--- a/es/tutorials/tour/_posts/2017-02-13-classes.md
+++ b/es/tutorials/tour/_posts/2017-02-13-classes.md
@@ -8,6 +8,9 @@ tutorial: scala-tour
 categories: tour
 num: 4
 language: es
+
+next-page: case-classes
+previous-page: annotations
 ---
 En Scala, las clases son plantillas estáticas que pueden ser instanciadas por muchos objetos en tiempo de ejecución.
 Aquí se presenta una clase la cual define la clase `Point`:

--- a/es/tutorials/tour/_posts/2017-02-13-compound-types.md
+++ b/es/tutorials/tour/_posts/2017-02-13-compound-types.md
@@ -8,6 +8,9 @@ tutorial: scala-tour
 categories: tour
 num: 6
 language: es
+
+next-page: sequence-comprehensions
+previous-page: case-classes
 ---
 
 Algunas veces es necesario expresar que el tipo de un objeto es un subtipo de varios otros tipos. En Scala esto puede ser expresado con la ayuda de *tipos compuestos*, los cuales pueden entenderse como la intersección de otros tipos.

--- a/es/tutorials/tour/_posts/2017-02-13-currying.md
+++ b/es/tutorials/tour/_posts/2017-02-13-currying.md
@@ -8,6 +8,9 @@ tutorial: scala-tour
 categories: tour
 num: 15
 language: es
+
+next-page: automatic-closures
+previous-page: anonymous-function-syntax
 ---
 
 _Nota de traducción: Currying es una técnica de programación funcional nombrada en honor al matemático y lógico Haskell Curry. Es por eso que no se intentará hacer ninguna traducción sobre el término Currying. Entiendase este como una acción, técnica base de PF. Como una nota al paso, el lenguaje de programación Haskell debe su nombre a este eximio matemático._

--- a/es/tutorials/tour/_posts/2017-02-13-default-parameter-values.md
+++ b/es/tutorials/tour/_posts/2017-02-13-default-parameter-values.md
@@ -8,6 +8,9 @@ tutorial: scala-tour
 categories: tour
 num: 34
 language: es
+
+next-page: named-parameters
+previous-page: implicit-conversions
 ---
 
 Scala tiene la capacidad de dar a los parámetros valores por defecto que pueden ser usados para permitir a quien invoca el método o función que omita dichos parámetros.

--- a/es/tutorials/tour/_posts/2017-02-13-explicitly-typed-self-references.md
+++ b/es/tutorials/tour/_posts/2017-02-13-explicitly-typed-self-references.md
@@ -8,6 +8,9 @@ tutorial: scala-tour
 categories: tour
 num: 27
 language: es
+
+next-page: local-type-inference
+previous-page: lower-type-bounds
 ---
 
 Cuando se está construyendo software extensible, algunas veces resulta útil declarar el tipo de la variable `this` explícitamente. Para motivar esto, realizaremos una pequeña representación de una estructura de datos Grafo, en Scala.

--- a/es/tutorials/tour/_posts/2017-02-13-extractor-objects.md
+++ b/es/tutorials/tour/_posts/2017-02-13-extractor-objects.md
@@ -8,6 +8,9 @@ tutorial: scala-tour
 categories: tour
 num: 8
 language: es
+
+next-page: generic-classes
+previous-page: sequence-comprehensions
 ---
 
 En Scala pueden ser definidos patrones independientemente de las clases Caso (en inglés case classes, desde ahora clases Case). Para este fin exite un método llamado `unapply` que proveera el ya dicho extractor. Por ejemplo, en el código siguiente se define el objeto extractor `Twice`

--- a/es/tutorials/tour/_posts/2017-02-13-generic-classes.md
+++ b/es/tutorials/tour/_posts/2017-02-13-generic-classes.md
@@ -8,6 +8,9 @@ tutorial: scala-tour
 categories: tour
 num: 9
 language: es
+
+next-page: implicit-parameters
+previous-page: extractor-objects
 ---
 
 Tal como en Java 5 ([JDK 1.5](http://java.sun.com/j2se/1.5/)), Scala provee soporte nativo para clases parametrizados con tipos. Eso es llamado clases genéricas y son especialmente importantes para el desarrollo de clases tipo colección.

--- a/es/tutorials/tour/_posts/2017-02-13-higher-order-functions.md
+++ b/es/tutorials/tour/_posts/2017-02-13-higher-order-functions.md
@@ -8,6 +8,9 @@ tutorial: scala-tour
 categories: tour
 num: 18
 language: es
+
+next-page: pattern-matching
+previous-page: operators
 ---
 
 Scala permite la definición de funciones de orden superior. Estas funciones son las que _toman otras funciones como parámetros_, o las cuales _el resultado es una función_. Aquí mostramos una función `apply` la cual toma otra función `f` y un valor `v` como parámetros y aplica la función `f` a `v`:

--- a/es/tutorials/tour/_posts/2017-02-13-implicit-conversions.md
+++ b/es/tutorials/tour/_posts/2017-02-13-implicit-conversions.md
@@ -8,6 +8,9 @@ tutorial: scala-tour
 categories: tour
 num: 32
 language: es
+
+next-page: default-parameter-values
+previous-page: variances
 ---
 
 (this page has not been translated into Spanish)

--- a/es/tutorials/tour/_posts/2017-02-13-implicit-parameters.md
+++ b/es/tutorials/tour/_posts/2017-02-13-implicit-parameters.md
@@ -8,6 +8,9 @@ tutorial: scala-tour
 categories: tour
 num: 10
 language: es
+
+next-page: inner-classes
+previous-page: generic-classes
 ---
 
 Un método con _parámetros implícitos_ puede ser aplicado a argumentos tal como un método normal. En este caso la etiqueta `implicit` no tiene efecto. De todas maneras, si a un método le faltan argumentos para sus parámetros implícitos, tales argumentos serán automáticamente provistos.

--- a/es/tutorials/tour/_posts/2017-02-13-inner-classes.md
+++ b/es/tutorials/tour/_posts/2017-02-13-inner-classes.md
@@ -8,6 +8,9 @@ tutorial: scala-tour
 categories: tour
 num: 11
 language: es
+
+next-page: mixin-class-composition
+previous-page: implicit-parameters
 ---
 
 En Scala es posible que las clases tengan como miembro otras clases. A diferencia de lenguajes similares a Java donde ese tipo de clases internas son miembros de las clases que las envuelven, en Scala esas clases internas están ligadas al objeto externo. Para ilustrar esta diferencia, vamos a mostrar rápidamente una implementación del tipo grafo:

--- a/es/tutorials/tour/_posts/2017-02-13-local-type-inference.md
+++ b/es/tutorials/tour/_posts/2017-02-13-local-type-inference.md
@@ -8,6 +8,9 @@ tutorial: scala-tour
 categories: tour
 num: 29
 language: es
+
+next-page: unified-types
+previous-page: explicitly-typed-self-references
 ---
 
 Scala tiene incorporado un mecanismo de inferencia de tipos el cual permite al programador omitir ciertos tipos de anotaciones. Por ejemplo, generalmente no es necesario especificar el tipo de una variable, ya que el compilador puede deducir el tipo mediante la expresión de inicialización de la variable. También puede generalmente omitirse los tipos de retorno de métodos ya que se corresponden con el tipo del cuerpo, que es inferido por el compilador. 

--- a/es/tutorials/tour/_posts/2017-02-13-lower-type-bounds.md
+++ b/es/tutorials/tour/_posts/2017-02-13-lower-type-bounds.md
@@ -8,6 +8,9 @@ tutorial: scala-tour
 categories: tour
 num: 26
 language: es
+
+next-page: explicitly-typed-self-references
+previous-page: upper-type-bounds
 ---
 
 Mientras que los [límites de tipado superior](upper-type-bounds.html) limitan el tipo de un subtipo de otro tipo, los *límites de tipado inferior* declaran que un tipo sea un supertipo de otro tipo. El término `T >: A` expresa que el parámetro de tipo `T` o el tipo abstracto `T` se refiera a un supertipo del tipo `A`

--- a/es/tutorials/tour/_posts/2017-02-13-mixin-class-composition.md
+++ b/es/tutorials/tour/_posts/2017-02-13-mixin-class-composition.md
@@ -8,6 +8,9 @@ tutorial: scala-tour
 categories: tour
 num: 12
 language: es
+
+next-page: singleton-objects
+previous-page: inner-classes
 ---
 _Nota de traducción: La palabra `mixin` puede ser traducida como mezcla, dando título a esta sección de: Composición de clases Mezcla, pero es preferible utilizar la notación original_
 

--- a/es/tutorials/tour/_posts/2017-02-13-named-parameters.md
+++ b/es/tutorials/tour/_posts/2017-02-13-named-parameters.md
@@ -8,6 +8,8 @@ tutorial: scala-tour
 categories: tour
 num: 35
 language: es
+
+previous-page: default-parameter-values
 ---
 
 En la invocación de métodos y funciones se puede usar el nombre de las variables explícitamente en la llamada, de la siguiente manera:

--- a/es/tutorials/tour/_posts/2017-02-13-nested-functions.md
+++ b/es/tutorials/tour/_posts/2017-02-13-nested-functions.md
@@ -8,6 +8,9 @@ tutorial: scala-tour
 categories: tour
 num: 13
 language: es
+
+next-page: anonymous-function-syntax
+previous-page: singleton-objects
 ---
 
 En scala es posible anidar definiciones de funciones. El siguiente objeto provee una función `filter` para extraer valores de una lista de enteros que están por debajo de un valor determinado:

--- a/es/tutorials/tour/_posts/2017-02-13-operators.md
+++ b/es/tutorials/tour/_posts/2017-02-13-operators.md
@@ -8,6 +8,9 @@ tutorial: scala-tour
 categories: tour
 num: 17
 language: es
+
+next-page: higher-order-functions
+previous-page: automatic-closures
 ---
 
 En Scala, cualquier método el cual reciba un solo parámetro puede ser usado como un *operador de infijo (infix)*. Aquí se muestra la definición de la clase `MyBool`, la cual define tres métodos `and`, `or`, y `negate`.

--- a/es/tutorials/tour/_posts/2017-02-13-pattern-matching.md
+++ b/es/tutorials/tour/_posts/2017-02-13-pattern-matching.md
@@ -8,6 +8,9 @@ tutorial: scala-tour
 categories: tour
 num: 20
 language: es
+
+next-page: polymorphic-methods
+previous-page: higher-order-functions
 ---
 
 _Nota de traducción: Es dificil encontrar en nuestro idioma una palabra que se relacione directamente con el significado de `match` en inglés. Podemos entender a `match` como "coincidir" o "concordar" con algo. En algunos lugares se utiliza la palabra `machear`, aunque esta no existe en nuestro idioma con el sentido que se le da en este texto, sino que se utiliza como traducción de `match`._

--- a/es/tutorials/tour/_posts/2017-02-13-polymorphic-methods.md
+++ b/es/tutorials/tour/_posts/2017-02-13-polymorphic-methods.md
@@ -8,6 +8,9 @@ tutorial: scala-tour
 categories: tour
 num: 21
 language: es
+
+next-page: regular-expression-patterns
+previous-page: pattern-matching
 ---
 
 Los métodos en Scala pueden ser parametrizados tanto con valores como con tipos. Como a nivel de clase, parámetros de valores son encerrados en un par de paréntesis, mientras que los parámetros de tipo son declarados dentro de un par de corchetes.

--- a/es/tutorials/tour/_posts/2017-02-13-regular-expression-patterns.md
+++ b/es/tutorials/tour/_posts/2017-02-13-regular-expression-patterns.md
@@ -8,6 +8,9 @@ tutorial: scala-tour
 categories: tour
 num: 22
 language: es
+
+next-page: traits
+previous-page: polymorphic-methods
 ---
 
 ## Patrones de secuencias que ignoran a la derecha ##

--- a/es/tutorials/tour/_posts/2017-02-13-sequence-comprehensions.md
+++ b/es/tutorials/tour/_posts/2017-02-13-sequence-comprehensions.md
@@ -8,6 +8,9 @@ tutorial: scala-tour
 categories: tour
 num: 7
 language: es
+
+next-page: extractor-objects
+previous-page: compound-types
 ---
 
 Scala cuenta con una notación ligera para expresar *sequencias por comprensión* (*sequence comprehensions*). Las comprensiones tienen la forma `for (enumeradores) yield e`, donde `enumeradores` se refiere a una lista de enumeradores separados por el símbolo punto y coma (;). Un *enumerador* puede ser tanto un generador el cual introduce nuevas variables, o un filtro. La comprensión evalúa el cuerpo `e` por cada paso (o ciclo) generado por los enumeradores y retorna una secuencia de estos valores.

--- a/es/tutorials/tour/_posts/2017-02-13-singleton-objects.md
+++ b/es/tutorials/tour/_posts/2017-02-13-singleton-objects.md
@@ -8,8 +8,9 @@ tutorial: scala-tour
 categories: tour
 num: 12
 language: es
-next-page: regular-expression-patterns
-previous-page: pattern-matching
+
+next-page: nested-functions
+previous-page: mixin-class-composition
 ---
 
 Métodos y valores que no están asociados con instancias individuales de una [clase](classes.html) se denominan *objetos singleton* y se denotan con la palabra reservada `object` en vez de `class`.

--- a/es/tutorials/tour/_posts/2017-02-13-singleton-objects.md
+++ b/es/tutorials/tour/_posts/2017-02-13-singleton-objects.md
@@ -8,7 +8,7 @@ tutorial: scala-tour
 categories: tour
 num: 12
 language: es
-next-page: xml-processing
+next-page: regular-expression-patterns
 previous-page: pattern-matching
 ---
 

--- a/es/tutorials/tour/_posts/2017-02-13-tour-of-scala.md
+++ b/es/tutorials/tour/_posts/2017-02-13-tour-of-scala.md
@@ -8,6 +8,8 @@ tutorial: scala-tour
 categories: tour
 num: 1
 language: es
+
+next-page: abstract-types
 ---
 
 Scala es un lenguaje de programación moderno multi-paradigma diseñado para expresar patrones de programación comunes de una forma concisa, elegante, y de tipado seguro. Integra fácilmente características de lenguajes orientados a objetos y funcionales.

--- a/es/tutorials/tour/_posts/2017-02-13-traits.md
+++ b/es/tutorials/tour/_posts/2017-02-13-traits.md
@@ -8,6 +8,9 @@ tutorial: scala-tour
 categories: tour
 num: 24
 language: es
+
+next-page: upper-type-bounds
+previous-page: regular-expression-patterns
 ---
 
 _Nota de traducción: La palabra `trait` en inglés puede traducirse literalmente como `rasgo` o `caracteristica`. Preferimos la designación original trait por ser una característica muy natural de Scala._

--- a/es/tutorials/tour/_posts/2017-02-13-unified-types.md
+++ b/es/tutorials/tour/_posts/2017-02-13-unified-types.md
@@ -8,6 +8,9 @@ tutorial: scala-tour
 categories: tour
 num: 30
 language: es
+
+next-page: variances
+previous-page: local-type-inference
 ---
 
 A diferencia de Java, todos los valores en Scala son objetos (incluyendo valores numéricos y funciones). Dado que Scala está basado en clases, todos los valores son instancias de una clase. El diagrama siguiente ilustra esta jerarquía de clases:

--- a/es/tutorials/tour/_posts/2017-02-13-upper-type-bounds.md
+++ b/es/tutorials/tour/_posts/2017-02-13-upper-type-bounds.md
@@ -8,6 +8,9 @@ tutorial: scala-tour
 categories: tour
 num: 25
 language: es
+
+next-page: lower-type-bounds
+previous-page: traits
 ---
 
 En Scala, los [parámetros de tipo](generic-classes.html) y los [tipos abstractos](abstract-types.html) pueden ser restringidos por un límite de tipado. Tales límites de tipado limitan los valores concretos de las variables de tipo y posiblemente revelan más información acerca de los miembros de tales tipos. Un _límite de tipado superior_ `T <: A` declara que la variable de tipo `T` es un subtipo del tipo `A`.

--- a/es/tutorials/tour/_posts/2017-02-13-variances.md
+++ b/es/tutorials/tour/_posts/2017-02-13-variances.md
@@ -8,6 +8,9 @@ tutorial: scala-tour
 categories: tour
 num: 31
 language: es
+
+next-page: implicit-conversions
+previous-page: unified-types
 ---
 
 Scala soporta anotaciones de varianza para parámetros de tipo para [clases genéricas](generic-classes.html). A diferencia de Java 5 ([JDK 1.5](http://java.sun.com/j2se/1.5/)), las anotaciones de varianza pueden ser agregadas cuando una abstracción de clase es definidia, mientras que en Java 5, las anotaciones de varianza son dadas por los clientes cuando una albstracción de clase es usada.

--- a/ko/tutorials/tour/_posts/2017-02-13-abstract-types.md
+++ b/ko/tutorials/tour/_posts/2017-02-13-abstract-types.md
@@ -9,6 +9,9 @@ categories: tour
 num: 22
 outof: 35
 language: ko
+
+next-page: compound-types
+previous-page: inner-classes
 ---
 
 스칼라에선 값(생성자 파라미터)과 타입(클래스가 [제네릭](generic-classes.html)일 경우)으로 클래스가 매개변수화된다. 규칙성을 지키기 위해, 값이 객체 멤버가 될 수 있을 뿐만 아니라 값의 타입 역시 객체의 멤버가 된다. 또한 이런 두 형태의 멤버 모두 다 구체화되거나 추상화될 수 있다.

--- a/ko/tutorials/tour/_posts/2017-02-13-annotations.md
+++ b/ko/tutorials/tour/_posts/2017-02-13-annotations.md
@@ -8,6 +8,9 @@ tutorial: scala-tour
 categories: tour
 num: 31
 language: ko
+
+next-page: default-parameter-values
+previous-page: automatic-closures
 ---
 
 어노테이션은 메타 정보와 정의 내용을 연결해준다.

--- a/ko/tutorials/tour/_posts/2017-02-13-anonymous-function-syntax.md
+++ b/ko/tutorials/tour/_posts/2017-02-13-anonymous-function-syntax.md
@@ -8,6 +8,9 @@ tutorial: scala-tour
 categories: tour
 num: 6
 language: ko
+
+next-page: higher-order-functions
+previous-page: mixin-class-composition
 ---
 
 스칼라를 사용하면 비교적 간결한 구문을 통해 익명 함수를 정의할 수 있다. 다음 표현식은 정수의 지정 함수를 만들어준다.

--- a/ko/tutorials/tour/_posts/2017-02-13-automatic-closures.md
+++ b/ko/tutorials/tour/_posts/2017-02-13-automatic-closures.md
@@ -8,6 +8,9 @@ tutorial: scala-tour
 categories: tour
 num: 30
 language: ko
+
+next-page: annotations
+previous-page: operators
 ---
 
 스칼라에선 파라미터가 없는 함수의 이름을 메소드의 파라미터로 사용할 수 있다. 이런 메소드가 호출되면 파라미터가 없는 함수의 이름에 해당하는 실제 파라미터를 찾지 않고, 대신 해당 파라미터의 계산을 캡슐화한 무항 함수를 전달하게 된다(소위 말하는 *이름에 의한 호출* 연산).

--- a/ko/tutorials/tour/_posts/2017-02-13-case-classes.md
+++ b/ko/tutorials/tour/_posts/2017-02-13-case-classes.md
@@ -8,6 +8,9 @@ tutorial: scala-tour
 categories: tour
 num: 10
 language: ko
+
+next-page: pattern-matching
+previous-page: currying
 ---
 
 스칼라는 _케이스 클래스_ 개념을 지원한다. 케이스 클래스는 아래와 같은 특징을 가지는 일반 클래스이다.

--- a/ko/tutorials/tour/_posts/2017-02-13-classes.md
+++ b/ko/tutorials/tour/_posts/2017-02-13-classes.md
@@ -8,6 +8,9 @@ tutorial: scala-tour
 categories: tour
 num: 3
 language: ko
+
+next-page: traits
+previous-page: unified-types
 ---
 
 스칼라의 클래스는 런타임에 많은 객체로 인스턴스화 될 수 있는 정적 템플릿이다.

--- a/ko/tutorials/tour/_posts/2017-02-13-compound-types.md
+++ b/ko/tutorials/tour/_posts/2017-02-13-compound-types.md
@@ -8,6 +8,9 @@ tutorial: scala-tour
 categories: tour
 num: 23
 language: ko
+
+next-page: explicitly-typed-self-references
+previous-page: abstract-types
 ---
 
 때론 객체의 타입을 여러 다른 타입의 서브타입으로 표현해야 할 때가 있다. 스칼라에선 *합성 타입(Compound Types)*으로 표현될 수 있는데, 이는 객체 타입들의 교차점을 의미한다.

--- a/ko/tutorials/tour/_posts/2017-02-13-currying.md
+++ b/ko/tutorials/tour/_posts/2017-02-13-currying.md
@@ -8,6 +8,9 @@ tutorial: scala-tour
 categories: tour
 num: 9
 language: ko
+
+next-page: case-classes
+previous-page: nested-functions
 ---
 
 메소드에는 파라미터 목록을 여럿 정의할 수 있다. 파라미터 목록의 수 보다 적은 파라미터로 메소드가 호출되면, 해당 함수는 누락된 파라미터 목록을 인수로 받는 새로운 함수를 만든다.

--- a/ko/tutorials/tour/_posts/2017-02-13-default-parameter-values.md
+++ b/ko/tutorials/tour/_posts/2017-02-13-default-parameter-values.md
@@ -8,6 +8,9 @@ tutorial: scala-tour
 categories: tour
 num: 32
 language: ko
+
+next-page: named-parameters
+previous-page: annotations
 ---
 
 스칼라는 파라미터에 기본 값을 부여해서 호출자가 해당 파라미터를 생략할 수 있는 편리함을 제공한다.

--- a/ko/tutorials/tour/_posts/2017-02-13-explicitly-typed-self-references.md
+++ b/ko/tutorials/tour/_posts/2017-02-13-explicitly-typed-self-references.md
@@ -8,6 +8,9 @@ tutorial: scala-tour
 categories: tour
 num: 24
 language: ko
+
+next-page: implicit-parameters
+previous-page: compound-types
 ---
 
 확장 가능한 소프트웨어를 개발할 땐 `this` 값의 타입을 명시적으로 선언하는 편이 편리할 수도 있다. 이를 이해하기 위해 스칼라로 작성된 작고 확장 가능한 그래프 데이터 구조를 만들어 보기로 하자.

--- a/ko/tutorials/tour/_posts/2017-02-13-extractor-objects.md
+++ b/ko/tutorials/tour/_posts/2017-02-13-extractor-objects.md
@@ -8,6 +8,9 @@ tutorial: scala-tour
 categories: tour
 num: 15
 language: ko
+
+next-page: sequence-comprehensions
+previous-page: regular-expression-patterns
 ---
 
 스칼라에선 캐이스 클래스와 상관 없이 패턴을 정의할 수 있다. 이런 측면에서 추출자라 불리는 unapply라는 이름의 메소드를 정의한다. 예를 들어, 다음의 코드는 추출자 오브젝트 Twice를 정의한다.

--- a/ko/tutorials/tour/_posts/2017-02-13-generic-classes.md
+++ b/ko/tutorials/tour/_posts/2017-02-13-generic-classes.md
@@ -8,6 +8,9 @@ tutorial: scala-tour
 categories: tour
 num: 17
 language: ko
+
+next-page: variances
+previous-page: sequence-comprehensions
 ---
 
 자바 5(다른 이름은 [JDK 1.5](http://java.sun.com/j2se/1.5/))와 같이, 스칼라는 타입으로 파라미터화된 클래스의 빌트인 지원을 제공한다. 이런 제네릭 클래스는 특히 컬렉션 클래스의 개발에 유용하다. 이에 관한 예제를 살펴보자.

--- a/ko/tutorials/tour/_posts/2017-02-13-higher-order-functions.md
+++ b/ko/tutorials/tour/_posts/2017-02-13-higher-order-functions.md
@@ -8,6 +8,9 @@ tutorial: scala-tour
 categories: tour
 num: 7
 language: ko
+
+next-page: nested-functions
+previous-page: anonymous-function-syntax
 ---
 
 스칼라는 고차 함수의 정의를 허용한다. 이런 함수는 _다른 함수를 파라미터로 받거나_, 수행의 _결과가 함수다_. 다음과 같은 함수 `apply`는 다른 함수 `f`와 값 `v`를 받아서 함수 `f`를 `v`에 적용한다.

--- a/ko/tutorials/tour/_posts/2017-02-13-implicit-conversions.md
+++ b/ko/tutorials/tour/_posts/2017-02-13-implicit-conversions.md
@@ -5,8 +5,12 @@ title: 암시적 변환
 discourse: true
 
 tutorial: scala-tour
+categories: tour
 num: 26
 language: ko
+
+next-page: polymorphic-methods
+previous-page: implicit-parameters
 ---
 
 타입 `S`로부터 타입 `T`로의 암시적 변환는 함수 타입 `S => T`의 암시적 값이나 해당 타입으로 변환 가능한 암시적 메소드로 정의된다.

--- a/ko/tutorials/tour/_posts/2017-02-13-implicit-parameters.md
+++ b/ko/tutorials/tour/_posts/2017-02-13-implicit-parameters.md
@@ -9,7 +9,7 @@ categories: tour
 num: 25
 language: ko
 
-next-page: polymorphic-methods
+next-page: implicit-conversions
 previous-page: explicitly-typed-self-references
 ---
 

--- a/ko/tutorials/tour/_posts/2017-02-13-implicit-parameters.md
+++ b/ko/tutorials/tour/_posts/2017-02-13-implicit-parameters.md
@@ -8,6 +8,9 @@ tutorial: scala-tour
 categories: tour
 num: 25
 language: ko
+
+next-page: polymorphic-methods
+previous-page: explicitly-typed-self-references
 ---
 
 _암시적 파라미터_ 를 갖는 메서드 역시 다른 일반적인 메서드와 마찬가지로 인수를 적용할 수 있다. 이런 경우 implicit 키워드는 아무런 영향을 미치지 않는다. 하지만, 이 경우에 암시적 파라미터에 주는 인수를 생략한다면, 그 생략된 인수는 자동적으로 제공될 것이다.

--- a/ko/tutorials/tour/_posts/2017-02-13-inner-classes.md
+++ b/ko/tutorials/tour/_posts/2017-02-13-inner-classes.md
@@ -8,6 +8,9 @@ tutorial: scala-tour
 categories: tour
 num: 21
 language: ko
+
+next-page: abstract-types
+previous-page: lower-type-bounds
 ---
 
 스칼라의 클래스는 다른 클래스를 멤버로 가질 수 있다. 자바와 같은 언어의 내부 클래스는 자신을 감싸고 있는 클래스의 멤버인 반면에, 스칼라에선 내부 클래스가 외부 객체의 경계 안에 있다. 이런 차이점을 분명히 하기 위해 그래프 데이터타입의 구현을 간단히 그려보자.

--- a/ko/tutorials/tour/_posts/2017-02-13-local-type-inference.md
+++ b/ko/tutorials/tour/_posts/2017-02-13-local-type-inference.md
@@ -8,6 +8,9 @@ tutorial: scala-tour
 categories: tour
 num: 28
 language: ko
+
+next-page: operators
+previous-page: polymorphic-methods
 ---
 
 스칼라는 프로그래머가 특정한 타입 어노테이션을 생략할 수 있도록 해주는 빌트인 타입 추론 기능을 갖추고 있다. 예를 들어, 스칼라에선 컴파일러가 변수의 초기화 표현식으로부터 타입을 추론할 수 있기 때문에 변수의 타입을 지정할 필요가 없을 때가 많다. 또한 메소드의 반환 타입은 본문의 타입과 일치하기 때문에 이 반환 타입 역시 컴파일러가 추론할 수 있고, 주로 생략된다.

--- a/ko/tutorials/tour/_posts/2017-02-13-lower-type-bounds.md
+++ b/ko/tutorials/tour/_posts/2017-02-13-lower-type-bounds.md
@@ -8,6 +8,9 @@ tutorial: scala-tour
 categories: tour
 num: 20
 language: ko
+
+next-page: inner-classes
+previous-page: upper-type-bounds
 ---
 
 [상위 타입 경계](upper-type-bounds.html)가 특정 타입의 서브타입으로 타입을 제한한다면, *하위 타입 경계*는 대상 타입을 다른 타입의 슈퍼타입으로 선언한다. `T>:A`는 타입 파라미터 `T`나 추상 타입 `T`가 타입 `A`의 슈퍼타입임을 나타낸다.

--- a/ko/tutorials/tour/_posts/2017-02-13-mixin-class-composition.md
+++ b/ko/tutorials/tour/_posts/2017-02-13-mixin-class-composition.md
@@ -8,6 +8,9 @@ tutorial: scala-tour
 categories: tour
 num: 5
 language: ko
+
+next-page: anonymous-function-syntax
+previous-page: traits
 ---
 
 _단일 상속_ 만을 지원하는 여러 언어와는 달리, 스칼라는 더욱 일반화된 시각에서 클래스를 재사용한다. 스칼라는 새로운 클래스를 정의할 때 _클래스의 새로운 멤버 정의_ (즉, 슈퍼클래스와 비교할 때 변경된 부분)를 재사용할 수 있다. 이를 _믹스인 클래스 컴포지션_ 이라고 부른다. 이터레이터를 추상화한 다음 예제를 살펴보자.

--- a/ko/tutorials/tour/_posts/2017-02-13-named-parameters.md
+++ b/ko/tutorials/tour/_posts/2017-02-13-named-parameters.md
@@ -8,6 +8,8 @@ tutorial: scala-tour
 categories: tour
 num: 33
 language: ko
+
+previous-page: default-parameter-values
 ---
 
 메소드와 함수를 호출할 땐 다음과 같이 해당 호출에서 명시적으로 변수의 이름을 사용할 수 있다.

--- a/ko/tutorials/tour/_posts/2017-02-13-nested-functions.md
+++ b/ko/tutorials/tour/_posts/2017-02-13-nested-functions.md
@@ -8,6 +8,9 @@ tutorial: scala-tour
 categories: tour
 num: 8
 language: ko
+
+next-page: currying
+previous-page: higher-order-functions
 ---
 
 스칼라에선 중첩 함수를 정의할 수 있다. 다음 오브젝트는 정수의 리스트에서 지정된 값보다 작은 값을 값을 추출해주는 `filter` 함수를 제공한다.

--- a/ko/tutorials/tour/_posts/2017-02-13-operators.md
+++ b/ko/tutorials/tour/_posts/2017-02-13-operators.md
@@ -8,6 +8,9 @@ tutorial: scala-tour
 categories: tour
 num: 29
 language: ko
+
+next-page: automatic-closures
+previous-page: local-type-inference
 ---
 
 스칼라에선 단일 파라미터를 취하는 모든 메소드를 *중위 연산자*로 사용할 수 있다. 다음은 `and`와 `or`, `negate` 등의 세 가지 메소드를 정의하고 있는 클래스 `MyBool`의 정의다.

--- a/ko/tutorials/tour/_posts/2017-02-13-pattern-matching.md
+++ b/ko/tutorials/tour/_posts/2017-02-13-pattern-matching.md
@@ -9,7 +9,7 @@ categories: tour
 num: 11
 language: ko
 
-next-page: regular-expression-patterns
+next-page: singleton-objects
 previous-page: case-classes
 ---
 

--- a/ko/tutorials/tour/_posts/2017-02-13-pattern-matching.md
+++ b/ko/tutorials/tour/_posts/2017-02-13-pattern-matching.md
@@ -8,6 +8,9 @@ tutorial: scala-tour
 categories: tour
 num: 11
 language: ko
+
+next-page: regular-expression-patterns
+previous-page: case-classes
 ---
 
 스칼라는 범용적 빌트인 패턴 매칭 기능을 제공한다. 이는 우선 매칭 정책에 따라 어떤 종류의 데이터든 매칭할 수 있도록 해준다.

--- a/ko/tutorials/tour/_posts/2017-02-13-polymorphic-methods.md
+++ b/ko/tutorials/tour/_posts/2017-02-13-polymorphic-methods.md
@@ -8,6 +8,9 @@ tutorial: scala-tour
 categories: tour
 num: 27
 language: ko
+
+next-page: local-type-inference
+previous-page: implicit-parameters
 ---
 
 스칼라의 메소드는 값과 타입 모두가 파라미터화 될 수 있다. 클래스 수준에서와 같이, 값 파라미터는 괄호의 쌍으로 묶이며 타입 파라미터는 브래킷의 쌍 안에 위치한다.

--- a/ko/tutorials/tour/_posts/2017-02-13-polymorphic-methods.md
+++ b/ko/tutorials/tour/_posts/2017-02-13-polymorphic-methods.md
@@ -10,7 +10,7 @@ num: 27
 language: ko
 
 next-page: local-type-inference
-previous-page: implicit-parameters
+previous-page: implicit-conversions
 ---
 
 스칼라의 메소드는 값과 타입 모두가 파라미터화 될 수 있다. 클래스 수준에서와 같이, 값 파라미터는 괄호의 쌍으로 묶이며 타입 파라미터는 브래킷의 쌍 안에 위치한다.

--- a/ko/tutorials/tour/_posts/2017-02-13-regular-expression-patterns.md
+++ b/ko/tutorials/tour/_posts/2017-02-13-regular-expression-patterns.md
@@ -8,6 +8,9 @@ tutorial: scala-tour
 categories: tour
 num: 14
 language: ko
+
+next-page: extractor-objects
+previous-page: pattern-matching
 ---
 
 ## 우측 무시 시퀀스 패턴 ##

--- a/ko/tutorials/tour/_posts/2017-02-13-regular-expression-patterns.md
+++ b/ko/tutorials/tour/_posts/2017-02-13-regular-expression-patterns.md
@@ -10,7 +10,7 @@ num: 14
 language: ko
 
 next-page: extractor-objects
-previous-page: pattern-matching
+previous-page: singleton-objects
 ---
 
 ## 우측 무시 시퀀스 패턴 ##

--- a/ko/tutorials/tour/_posts/2017-02-13-sequence-comprehensions.md
+++ b/ko/tutorials/tour/_posts/2017-02-13-sequence-comprehensions.md
@@ -8,6 +8,9 @@ tutorial: scala-tour
 categories: tour
 num: 16
 language: ko
+
+next-page: generic-classes
+previous-page: extractor-objects
 ---
 
 스칼라는 *시퀀스 컴프리헨션(sequence comprehensions)*을 표현하기 위한 간편한 문법을 제공한다. 컴프리헨션은 `for (enumerators) yield e`와 같은 형태를 가지며, 여기서 `enumerators`는 세미콜론으로 구분된 이뉴머레이터들을 뜻한다. *이뉴머레이터*는 새로운 변수를 정의하는 생성자이거나 필터이다. 컴프리헨션은 생성된 각각의 새로운 변수에 대해서 그 몸체인 `e`를 계산하여 그 값들의 시퀀스를 반환한다. 

--- a/ko/tutorials/tour/_posts/2017-02-13-singleton-objects.md
+++ b/ko/tutorials/tour/_posts/2017-02-13-singleton-objects.md
@@ -5,6 +5,7 @@ title: 싱글톤 객체
 discourse: true
 
 tutorial: scala-tour
+categories: tour
 num: 12
 language: ko
 

--- a/ko/tutorials/tour/_posts/2017-02-13-tour-of-scala.md
+++ b/ko/tutorials/tour/_posts/2017-02-13-tour-of-scala.md
@@ -8,6 +8,8 @@ tutorial: scala-tour
 categories: tour
 num: 1
 language: ko
+
+next-page: unified-types
 ---
 
 스칼라는 정확하고 명쾌하며 타입 세이프한 방식으로 일반적인 유형의 프로그래밍 패턴을 표현하기 위해 설계된 새로운 다중 패러다임 프로그래밍 언어다. 스칼라는 객체지향과 함수형 언어를 자연스럽게 통합해준다.

--- a/ko/tutorials/tour/_posts/2017-02-13-traits.md
+++ b/ko/tutorials/tour/_posts/2017-02-13-traits.md
@@ -8,6 +8,9 @@ tutorial: scala-tour
 categories: tour
 num: 4
 language: ko
+
+next-page: mixin-class-composition
+previous-page: classes
 ---
 
 트레잇은 자바의 인터페이스와 유사하며, 지원되는 메소드의 서명을 지정해 객체의 타입을 정의하는 데 사용한다. 자바와는 달리, 스칼라에선 트레잇의 일부만 구현할 수도 있다. 다시 말해, 일부 메소드를 선택해 기본 구현 내용을 사전에 정의할 수 있다. 클래스와는 달리, 트레잇은 생성자 파라미터를 가질 수 없다.

--- a/ko/tutorials/tour/_posts/2017-02-13-unified-types.md
+++ b/ko/tutorials/tour/_posts/2017-02-13-unified-types.md
@@ -8,6 +8,9 @@ tutorial: scala-tour
 categories: tour
 num: 2
 language: ko
+
+next-page: classes
+previous-page: tour-of-scala
 ---
 
 자바와는 달리, 스칼라에선 모든 값이 객체다(숫자 값과 함수를 포함해). 스칼라는 클래스 기반이기 때문에 모든 값은 클래스의 인스턴스다. 다음의 다이어그램은 클래스 계층구조를 나타낸다.

--- a/ko/tutorials/tour/_posts/2017-02-13-upper-type-bounds.md
+++ b/ko/tutorials/tour/_posts/2017-02-13-upper-type-bounds.md
@@ -8,6 +8,9 @@ tutorial: scala-tour
 categories: tour
 num: 19
 language: ko
+
+next-page: lower-type-bounds
+previous-page: variances
 ---
 
 스칼라에선 [타입 파라미터](generic-classes.html) 와 [추상 타입](abstract-types.html)의 타입 경계를 제한할 수 있다. 이런 타입 경계는 타입 변수의 콘크리트 값을 제한하고, 해당 타입의 멤버에 관한 정보를 추가할 수도 있다. _상위 타입 경계_ `T <: A`는 타입 변수 `T`를 선언하면서 서브타입 `A`를 참조하고 있다. 다음은 다형성 메소드 `findSimilar`의 구현을 위해 상위 타입 경계를 사용한 예제다.

--- a/ko/tutorials/tour/_posts/2017-02-13-variances.md
+++ b/ko/tutorials/tour/_posts/2017-02-13-variances.md
@@ -8,6 +8,9 @@ tutorial: scala-tour
 categories: tour
 num: 18
 language: ko
+
+next-page: upper-type-bounds
+previous-page: generic-classes
 ---
 
 스칼라는 [제네릭 클래스](generic-classes.html)의 타입 파라미터에 관한 가변성 어노테이션을 지원한다. 자바 5(다른 이름은 [JDK 1.5](http://java.sun.com/j2se/1.5/))에선 추상화된 클래스가 사용될 때 클라이언트가 가변성 어노테이션을 결정하지만, 반면에 스칼라는 추상화된 클래스를 정의할 때 가변성 어노테이션을 추가할 수 있다.

--- a/ko/tutorials/tour/singleton-objects.md
+++ b/ko/tutorials/tour/singleton-objects.md
@@ -8,7 +8,7 @@ tutorial: scala-tour
 num: 12
 language: ko
 
-next-page: xml-processing
+next-page: regular-expression-patterns
 previous-page: pattern-matching
 ---
 

--- a/pl/tutorials/tour/_posts/2017-02-13-abstract-types.md
+++ b/pl/tutorials/tour/_posts/2017-02-13-abstract-types.md
@@ -8,8 +8,8 @@ tutorial: scala-tour
 categories: tour
 num: 22
 language: pl
-tutorial-next: compound-types
-tutorial-previous: inner-classes
+next-page: compound-types
+previous-page: inner-classes
 ---
 
 W Scali klasy są parametryzowane wartościami (parametry konstruktora) oraz typami (jeżeli klasa jest [generyczna](generic-classes.html)). Aby zachować regularność, zarówno typy jak i wartości są elementami klasy. Analogicznie mogą one być konkretne albo abstrakcyjne.

--- a/pl/tutorials/tour/_posts/2017-02-13-annotations.md
+++ b/pl/tutorials/tour/_posts/2017-02-13-annotations.md
@@ -7,8 +7,8 @@ discourse: true
 tutorial: scala-tour
 categories: tour
 num: 31
-tutorial-next: default-parameter-values
-tutorial-previous: automatic-closures
+next-page: default-parameter-values
+previous-page: automatic-closures
 language: pl
 ---
 

--- a/pl/tutorials/tour/_posts/2017-02-13-anonymous-function-syntax.md
+++ b/pl/tutorials/tour/_posts/2017-02-13-anonymous-function-syntax.md
@@ -8,8 +8,8 @@ tutorial: scala-tour
 categories: tour
 num: 6
 language: pl
-tutorial-next: higher-order-functions
-tutorial-previous: mixin-class-composition
+next-page: higher-order-functions
+previous-page: mixin-class-composition
 ---
 
 Scala posiada lekką składnię pozwalającą na definiowanie funkcji anonimowych. Poniższe wyrażenie tworzy funkcję następnika dla liczb całkowitych:

--- a/pl/tutorials/tour/_posts/2017-02-13-automatic-closures.md
+++ b/pl/tutorials/tour/_posts/2017-02-13-automatic-closures.md
@@ -8,8 +8,8 @@ tutorial: scala-tour
 categories: tour
 num: 30
 language: pl
-tutorial-next: annotations
-tutorial-previous: operators
+next-page: annotations
+previous-page: operators
 ---
 
 Scala pozwala na przekazywanie funkcji bezparametrycznych jako argumenty dla metod. Kiedy tego typu metoda jest wywołana, właściwe parametry dla funkcji bezparametrycznych nie są ewaluowane i przekazywana jest pusta funkcja, która enkapsuluje obliczenia odpowiadającego parametru (tzw. *wywołanie-przez-nazwę*).

--- a/pl/tutorials/tour/_posts/2017-02-13-case-classes.md
+++ b/pl/tutorials/tour/_posts/2017-02-13-case-classes.md
@@ -8,8 +8,8 @@ tutorial: scala-tour
 categories: tour
 num: 10
 language: pl
-tutorial-next: pattern-matching
-tutorial-previous: currying
+next-page: pattern-matching
+previous-page: currying
 ---
 
 Scala wspiera mechanizm _klas przypadków_. Klasy przypadków są zwykłymi klasami z dodatkowymi założeniami:

--- a/pl/tutorials/tour/_posts/2017-02-13-classes.md
+++ b/pl/tutorials/tour/_posts/2017-02-13-classes.md
@@ -8,8 +8,8 @@ tutorial: scala-tour
 categories: tour
 num: 3
 language: pl
-tutorial-next: traits
-tutorial-previous: unified-types
+next-page: traits
+previous-page: unified-types
 ---
 
 Klasy w Scali określają schemat obiektów podczas wykonania programu. Oto przykład definicji klasy `Point`:

--- a/pl/tutorials/tour/_posts/2017-02-13-compound-types.md
+++ b/pl/tutorials/tour/_posts/2017-02-13-compound-types.md
@@ -8,8 +8,8 @@ tutorial: scala-tour
 categories: tour
 num: 23
 language: pl
-tutorial-next: explicitly-typed-self-references
-tutorial-previous: abstract-types
+next-page: explicitly-typed-self-references
+previous-page: abstract-types
 ---
 
 Czasami konieczne jest wyrażenie, że dany typ jest podtypem kilku innych typów. W Scali wyraża się to za pomocą *typów złożonych*, które są częścią wspólną typów obiektów.

--- a/pl/tutorials/tour/_posts/2017-02-13-currying.md
+++ b/pl/tutorials/tour/_posts/2017-02-13-currying.md
@@ -8,8 +8,8 @@ tutorial: scala-tour
 categories: tour
 num: 9
 language: pl
-tutorial-next: case-classes
-tutorial-previous: nested-functions
+next-page: case-classes
+previous-page: nested-functions
 ---
 
 Funkcja może określić dowolną ilość list parametrów. Kiedy jest ona wywołana dla mniejszej liczby niż zostało to zdefiniowane, zwraca funkcję pobierającą dalsze listy parametrów jako jej argument.

--- a/pl/tutorials/tour/_posts/2017-02-13-default-parameter-values.md
+++ b/pl/tutorials/tour/_posts/2017-02-13-default-parameter-values.md
@@ -8,8 +8,8 @@ tutorial: scala-tour
 categories: tour
 num: 32
 language: pl
-tutorial-next: named-parameters
-tutorial-previous: annotations
+next-page: named-parameters
+previous-page: annotations
 ---
 
 Scala zezwala na określenie domyślnych wartości dla parametrów, co pozwala wyrażeniu wywołującemu ją na pominięcie tych parametrów.

--- a/pl/tutorials/tour/_posts/2017-02-13-explicitly-typed-self-references.md
+++ b/pl/tutorials/tour/_posts/2017-02-13-explicitly-typed-self-references.md
@@ -8,8 +8,8 @@ tutorial: scala-tour
 categories: tour
 num: 24
 language: pl
-tutorial-next: implicit-parameters
-tutorial-previous: compound-types
+next-page: implicit-parameters
+previous-page: compound-types
 ---
 
 Dążąc do tego, aby nasze oprogramowanie było rozszerzalne, często przydatne okazuje się jawne deklarowanie typu `this`. Aby to umotywować, spróbujemy opracować rozszerzalną reprezentację grafu w Scali.

--- a/pl/tutorials/tour/_posts/2017-02-13-extractor-objects.md
+++ b/pl/tutorials/tour/_posts/2017-02-13-extractor-objects.md
@@ -8,8 +8,8 @@ tutorial: scala-tour
 categories: tour
 num: 15
 language: pl
-tutorial-next: sequence-comprehensions
-tutorial-previous: regular-expression-patterns
+next-page: sequence-comprehensions
+previous-page: regular-expression-patterns
 ---
 
 W Scali wzorce mogą być zdefiniowane niezależnie od klas przypadków. Obiekt posiadający metodę `unapply` może funkcjonować jako tak zwany ekstraktor. Jest to szczególna metoda, która pozwala na odwrócenie zastosowania obiektu dla pewnych danych. Jego celem jest ekstrakcja danych, z których został on utworzony. Dla przykładu, poniższy kod definiuje ekstraktor dla [obiektu](singleton-objects.html) `Twice`:

--- a/pl/tutorials/tour/_posts/2017-02-13-generic-classes.md
+++ b/pl/tutorials/tour/_posts/2017-02-13-generic-classes.md
@@ -8,8 +8,8 @@ tutorial: scala-tour
 categories: tour
 num: 17
 language: pl
-tutorial-next: variances
-tutorial-previous: sequence-comprehensions
+next-page: variances
+previous-page: sequence-comprehensions
 ---
 
 Scala posiada wbudowaną obsługą klas parametryzowanych przez typy. Tego typu klasy generyczne są szczególnie użyteczne podczas tworzenia klas kolekcji.

--- a/pl/tutorials/tour/_posts/2017-02-13-higher-order-functions.md
+++ b/pl/tutorials/tour/_posts/2017-02-13-higher-order-functions.md
@@ -8,8 +8,8 @@ tutorial: scala-tour
 categories: tour
 num: 7
 language: pl
-tutorial-next: nested-functions
-tutorial-previous: anonymous-function-syntax
+next-page: nested-functions
+previous-page: anonymous-function-syntax
 ---
 
 Scala pozwala na definiowanie funkcji wyższego rzędu. Są to funkcje, które przyjmują funkcje jako parametry lub których wynik jest też funkcją. Poniżej znajduje się przykład funkcji `apply`, która pobiera inną funkcję `f` i wartość `v` po to, by zwrócić wynik zastosowania `f` do `v`:

--- a/pl/tutorials/tour/_posts/2017-02-13-implicit-conversions.md
+++ b/pl/tutorials/tour/_posts/2017-02-13-implicit-conversions.md
@@ -8,8 +8,8 @@ tutorial: scala-tour
 categories: tour
 num: 26
 language: pl
-tutorial-next: polymorphic-methods
-tutorial-previous: implicit-parameters
+next-page: polymorphic-methods
+previous-page: implicit-parameters
 ---
 
 Konwersja niejawna z typu `S` do `T` jest określona przez wartość domniemaną, która jest funkcją typu `S => T` lub przez metodę domniemaną odpowiadającą funkcji tego typu.

--- a/pl/tutorials/tour/_posts/2017-02-13-implicit-parameters.md
+++ b/pl/tutorials/tour/_posts/2017-02-13-implicit-parameters.md
@@ -8,8 +8,8 @@ tutorial: scala-tour
 categories: tour
 num: 25
 language: pl
-tutorial-next: implicit-conversions
-tutorial-previous: explicitly-typed-self-references
+next-page: implicit-conversions
+previous-page: explicitly-typed-self-references
 ---
 
 Metodę z _parametrami domniemanymi_ można stosować tak samo jak każdą zwyczajną metodę. W takim przypadku etykieta `implicit` nie ma żadnego znaczenia. Jednak jeżeli odpowiednie argumenty dla parametrów domniemanych nie zostaną jawnie określone, to kompilator dostarczy je automatycznie.

--- a/pl/tutorials/tour/_posts/2017-02-13-inner-classes.md
+++ b/pl/tutorials/tour/_posts/2017-02-13-inner-classes.md
@@ -8,8 +8,8 @@ tutorial: scala-tour
 categories: tour
 num: 21
 language: pl
-tutorial-next: abstract-types
-tutorial-previous: lower-type-bounds
+next-page: abstract-types
+previous-page: lower-type-bounds
 ---
 
 W Scali możliwe jest zdefiniowanie klasy jako element innej klasy. W przeciwieństwie do języków takich jak Java, gdzie tego typu wewnętrzne klasy są elementami ujmujących ich klas, w Scali są one związane z zewnętrznym obiektem. Aby zademonstrować tę różnicę, stworzymy teraz prostą implementację grafu:

--- a/pl/tutorials/tour/_posts/2017-02-13-local-type-inference.md
+++ b/pl/tutorials/tour/_posts/2017-02-13-local-type-inference.md
@@ -8,8 +8,8 @@ tutorial: scala-tour
 categories: tour
 num: 28
 language: pl
-tutorial-next: operators
-tutorial-previous: polymorphic-methods
+next-page: operators
+previous-page: polymorphic-methods
 ---
 
 Scala posiada wbudowany mechanizm inferencji typów, który pozwala programiście pominąć pewne informacje o typach. Przykładowo zazwyczaj nie wymaga się podawania typów zmiennych, gdyż kompilator sam jest w stanie go wydedukować na podstawie typu wyrażenia inicjalizacji zmiennej. Także typy zwracane przez metody mogą być często pominięte, ponieważ odpowiadają one typowi ciała metody, który jest inferowany przez kompilator.

--- a/pl/tutorials/tour/_posts/2017-02-13-lower-type-bounds.md
+++ b/pl/tutorials/tour/_posts/2017-02-13-lower-type-bounds.md
@@ -8,8 +8,8 @@ tutorial: scala-tour
 categories: tour
 num: 20
 language: pl
-tutorial-next: inner-classes
-tutorial-previous: upper-type-bounds
+next-page: inner-classes
+previous-page: upper-type-bounds
 ---
 
 Podczas gdy [górne ograniczenia typów](upper-type-bounds.html) zawężają typ do podtypu innego typu, *dolne ograniczenia typów* określają dany typ jako typ bazowy innego typu. Sformułowanie `T >: A` wyraża, że parametr typu `T` lub typ abstrakcyjny `T` odwołuje się do typu bazowego `A`.

--- a/pl/tutorials/tour/_posts/2017-02-13-mixin-class-composition.md
+++ b/pl/tutorials/tour/_posts/2017-02-13-mixin-class-composition.md
@@ -8,8 +8,8 @@ tutorial: scala-tour
 categories: tour
 num: 5
 language: pl
-tutorial-next: anonymous-function-syntax
-tutorial-previous: traits
+next-page: anonymous-function-syntax
+previous-page: traits
 ---
 
 W przeciwieństwie do języków, które wspierają jedynie pojedyncze dziedziczenie, Scala posiada bardziej uogólniony mechanizm ponownego wykorzystania klas. Scala umożliwia wykorzystanie _nowych elementów klasy_ (różnicy w stosunku do klasy bazowej) w definicji nowej klasy. Wyraża się to przy pomocy _kompozycji domieszek_.

--- a/pl/tutorials/tour/_posts/2017-02-13-named-parameters.md
+++ b/pl/tutorials/tour/_posts/2017-02-13-named-parameters.md
@@ -8,7 +8,7 @@ tutorial: scala-tour
 categories: tour
 num: 33
 language: pl
-tutorial-previous: default-parameter-values
+previous-page: default-parameter-values
 ---
 
 Wywołując metody i funkcje, możesz użyć nazwy parametru jawnie podczas wywołania:

--- a/pl/tutorials/tour/_posts/2017-02-13-nested-functions.md
+++ b/pl/tutorials/tour/_posts/2017-02-13-nested-functions.md
@@ -8,8 +8,8 @@ tutorial: scala-tour
 categories: tour
 num: 8
 language: pl
-tutorial-next: currying
-tutorial-previous: higher-order-functions
+next-page: currying
+previous-page: higher-order-functions
 ---
 
 Scala pozwala na zagnieżdżanie definicji funkcji. Poniższy obiekt określa funkcję `filter`, która dla danej listy filtruje elementy większe bądź równe podanemu progowi `threshold`:

--- a/pl/tutorials/tour/_posts/2017-02-13-operators.md
+++ b/pl/tutorials/tour/_posts/2017-02-13-operators.md
@@ -8,8 +8,8 @@ tutorial: scala-tour
 categories: tour
 num: 29
 language: pl
-tutorial-next: automatic-closures
-tutorial-previous: local-type-inference
+next-page: automatic-closures
+previous-page: local-type-inference
 ---
 
 Każda metoda, która przyjmuje jeden parametr, może być użyta jako *operator infiksowy*. Oto definicja klasy `MyBool` która zawiera metody `and` i `or`:

--- a/pl/tutorials/tour/_posts/2017-02-13-pattern-matching.md
+++ b/pl/tutorials/tour/_posts/2017-02-13-pattern-matching.md
@@ -8,8 +8,8 @@ tutorial: scala-tour
 categories: tour
 num: 11
 language: pl
-tutorial-next: singleton-objects
-tutorial-previous: case-classes
+next-page: singleton-objects
+previous-page: case-classes
 ---
 
 Scala posiada wbudowany mechanizm dopasowania wzorców. Umożliwia on dopasowanie dowolnego rodzaju danych, przy czym zawsze zwracamy pierwsze dopasowanie. Przykład dopasowania liczby całkowitej:

--- a/pl/tutorials/tour/_posts/2017-02-13-polymorphic-methods.md
+++ b/pl/tutorials/tour/_posts/2017-02-13-polymorphic-methods.md
@@ -8,8 +8,8 @@ tutorial: scala-tour
 categories: tour
 num: 27
 language: pl
-tutorial-next: local-type-inference
-tutorial-previous: implicit-conversions
+next-page: local-type-inference
+previous-page: implicit-conversions
 ---
 
 Metody w Scali mogą być parametryzowane zarówno przez wartości, jak i typy. Tak jak na poziomie klas, wartości parametrów zawierają się w parze nawiasów okrągłych, podczas gdy parametry typów są deklarawane w parze nawiasów kwadratowych.

--- a/pl/tutorials/tour/_posts/2017-02-13-regular-expression-patterns.md
+++ b/pl/tutorials/tour/_posts/2017-02-13-regular-expression-patterns.md
@@ -9,8 +9,8 @@ categories: tour
 num: 14
 language: pl
 
-tutorial-next: extractor-objects
-tutorial-previous: singleton-objects
+next-page: extractor-objects
+previous-page: singleton-objects
 ---
 
 ## Wzorce sekwencji ignorujące prawą stronę ##

--- a/pl/tutorials/tour/_posts/2017-02-13-regular-expression-patterns.md
+++ b/pl/tutorials/tour/_posts/2017-02-13-regular-expression-patterns.md
@@ -10,7 +10,7 @@ num: 14
 language: pl
 
 tutorial-next: extractor-objects
-tutorial-previous: xml-processing
+tutorial-previous: singleton-objects
 ---
 
 ## Wzorce sekwencji ignorujące prawą stronę ##

--- a/pl/tutorials/tour/_posts/2017-02-13-sequence-comprehensions.md
+++ b/pl/tutorials/tour/_posts/2017-02-13-sequence-comprehensions.md
@@ -8,8 +8,8 @@ tutorial: scala-tour
 categories: tour
 num: 16
 language: pl
-tutorial-next: generic-classes
-tutorial-previous: extractor-objects
+next-page: generic-classes
+previous-page: extractor-objects
 ---
 
 Scala posiada lekką składnię do wyrażania instrukcji for. Tego typu wyrażania przybierają formę `for (enumerators) yield e`, gdzie `enumerators` oznacza listę enumeratorów oddzielonych średnikami. *Enumerator* może być generatorem wprowadzającym nowe zmienne albo filtrem. Wyrażenie `e` określa wynik dla każdego powiązania wygenerowanego przez enumeratory i zwraca sekwencję tych wartości.

--- a/pl/tutorials/tour/_posts/2017-02-13-singleton-objects.md
+++ b/pl/tutorials/tour/_posts/2017-02-13-singleton-objects.md
@@ -9,8 +9,8 @@ categories: tour
 num: 12
 language: pl
 
-tutorial-next: regular-expression-patterns
-tutorial-previous: pattern-matching
+next-page: regular-expression-patterns
+previous-page: pattern-matching
 ---
 
 Metody i wartości, które nie są powiązane z konkretną instancją [klasy](classes.html), należą do *obiektów singleton* określanych za pomocą słowa kluczowego `object` zamiast `class`.

--- a/pl/tutorials/tour/_posts/2017-02-13-singleton-objects.md
+++ b/pl/tutorials/tour/_posts/2017-02-13-singleton-objects.md
@@ -9,7 +9,7 @@ categories: tour
 num: 12
 language: pl
 
-tutorial-next: xml-processing
+tutorial-next: regular-expression-patterns
 tutorial-previous: pattern-matching
 ---
 

--- a/pl/tutorials/tour/_posts/2017-02-13-tour-of-scala.md
+++ b/pl/tutorials/tour/_posts/2017-02-13-tour-of-scala.md
@@ -9,7 +9,7 @@ categories: tour
 num: 1
 outof: 33
 language: pl
-tutorial-next: unified-types
+next-page: unified-types
 ---
 
 Scala jest nowoczesnym, wieloparadygmatowym językiem programowania zaprojektowanym do wyrażania powszechnych wzorców programistycznych w zwięzłym, eleganckim i bezpiecznie typowanym stylu. Scala płynnie integruje ze sobą cechy języków funkcyjnych i zorientowanych obiektowo.

--- a/pl/tutorials/tour/_posts/2017-02-13-traits.md
+++ b/pl/tutorials/tour/_posts/2017-02-13-traits.md
@@ -8,8 +8,8 @@ tutorial: scala-tour
 categories: tour
 num: 4
 language: pl
-tutorial-next: mixin-class-composition
-tutorial-previous: classes
+next-page: mixin-class-composition
+previous-page: classes
 ---
 
 Zbliżone do interfejsów Javy cechy są wykorzystywane do definiowania typów obiektów poprzez określenie sygnatur wspieranych metod. Podobnie jak w Javie 8, Scala pozwala cechom na częściową implementację, tzn. jest możliwe podanie domyślnej implementacji dla niektórych metod. W przeciwieństwie do klas, cechy nie mogą posiadać parametrów konstruktora.

--- a/pl/tutorials/tour/_posts/2017-02-13-unified-types.md
+++ b/pl/tutorials/tour/_posts/2017-02-13-unified-types.md
@@ -8,8 +8,8 @@ tutorial: scala-tour
 categories: tour
 num: 2
 language: pl
-tutorial-next: classes
-tutorial-previous: tour-of-scala
+next-page: classes
+previous-page: tour-of-scala
 ---
 
 W przeciwieństwie do Javy wszystkie wartości w Scali są obiektami (wliczając w to wartości numeryczne i funkcje). Ponieważ Scala bazuje na klasach, wszystkie wartości są instancjami klasy. Można zatem powiedzieć, że Scala posiada zunifikowany system typów. Poniższy diagram ilustruje hierarchię klas Scali:

--- a/pl/tutorials/tour/_posts/2017-02-13-upper-type-bounds.md
+++ b/pl/tutorials/tour/_posts/2017-02-13-upper-type-bounds.md
@@ -8,8 +8,8 @@ tutorial: scala-tour
 categories: tour
 num: 19
 language: pl
-tutorial-next: lower-type-bounds
-tutorial-previous: variances
+next-page: lower-type-bounds
+previous-page: variances
 ---
 
 W Scali [parametry typów](generic-classes.html) oraz [typy abstrakcyjne](abstract-types.html) mogą być warunkowane przez ograniczenia typów. Tego rodzaju ograniczenia pomagają określić konkretne wartości zmiennych typu oraz odkryć więcej informacji na temat elementów tych typów. _Ograniczenie górne typu_ `T <: A` zakładają, że zmienna `T` jest podtypem typu `A`.

--- a/pl/tutorials/tour/_posts/2017-02-13-variances.md
+++ b/pl/tutorials/tour/_posts/2017-02-13-variances.md
@@ -8,8 +8,8 @@ tutorial: scala-tour
 categories: tour
 num: 18
 language: pl
-tutorial-next: upper-type-bounds
-tutorial-previous: generic-classes
+next-page: upper-type-bounds
+previous-page: generic-classes
 ---
 
 Scala wspiera adnotacje wariancji parametrów typów [klas generycznych](generic-classes.html). W porównaniu do Javy adnotacje wariancji mogą zostać dodane podczas definiowania abstrakcji klasy, gdy w Javie adnotacje wariancji są podane przez użytkowników tych klas.

--- a/pt-br/tutorials/tour/_posts/2017-02-13-abstract-types.md
+++ b/pt-br/tutorials/tour/_posts/2017-02-13-abstract-types.md
@@ -7,8 +7,8 @@ discourse: true
 tutorial: scala-tour
 categories: tour
 num: 22
-tutorial-next: compound-types
-tutorial-previous: inner-classes
+next-page: compound-types
+previous-page: inner-classes
 language: pt-br
 ---
 

--- a/pt-br/tutorials/tour/_posts/2017-02-13-annotations.md
+++ b/pt-br/tutorials/tour/_posts/2017-02-13-annotations.md
@@ -7,8 +7,8 @@ discourse: true
 tutorial: scala-tour
 categories: tour
 num: 31
-tutorial-next: default-parameter-values
-tutorial-previous: automatic-closures
+next-page: default-parameter-values
+previous-page: automatic-closures
 language: pt-br
 ---
 

--- a/pt-br/tutorials/tour/_posts/2017-02-13-anonymous-function-syntax.md
+++ b/pt-br/tutorials/tour/_posts/2017-02-13-anonymous-function-syntax.md
@@ -7,8 +7,8 @@ discourse: true
 tutorial: scala-tour
 categories: tour
 num: 6
-tutorial-next: higher-order-functions
-tutorial-previous: mixin-class-composition
+next-page: higher-order-functions
+previous-page: mixin-class-composition
 language: pt-br
 ---
 

--- a/pt-br/tutorials/tour/_posts/2017-02-13-automatic-closures.md
+++ b/pt-br/tutorials/tour/_posts/2017-02-13-automatic-closures.md
@@ -7,8 +7,8 @@ discourse: true
 tutorial: scala-tour
 categories: tour
 num: 30
-tutorial-next: annotations
-tutorial-previous: operators
+next-page: annotations
+previous-page: operators
 language: pt-br
 ---
 

--- a/pt-br/tutorials/tour/_posts/2017-02-13-case-classes.md
+++ b/pt-br/tutorials/tour/_posts/2017-02-13-case-classes.md
@@ -7,8 +7,8 @@ discourse: true
 tutorial: scala-tour
 categories: tour
 num: 10
-tutorial-next: pattern-matching
-tutorial-previous: currying
+next-page: pattern-matching
+previous-page: currying
 language: pt-br
 ---
 

--- a/pt-br/tutorials/tour/_posts/2017-02-13-classes.md
+++ b/pt-br/tutorials/tour/_posts/2017-02-13-classes.md
@@ -7,8 +7,8 @@ discourse: true
 tutorial: scala-tour
 categories: tour
 num: 3
-tutorial-next: traits
-tutorial-previous: unified-types
+next-page: traits
+previous-page: unified-types
 language: pt-br
 ---
 

--- a/pt-br/tutorials/tour/_posts/2017-02-13-compound-types.md
+++ b/pt-br/tutorials/tour/_posts/2017-02-13-compound-types.md
@@ -7,8 +7,8 @@ discourse: true
 tutorial: scala-tour
 categories: tour
 num: 23
-tutorial-next: explicitly-typed-self-references
-tutorial-previous: abstract-types
+next-page: explicitly-typed-self-references
+previous-page: abstract-types
 language: pt-br
 ---
 

--- a/pt-br/tutorials/tour/_posts/2017-02-13-currying.md
+++ b/pt-br/tutorials/tour/_posts/2017-02-13-currying.md
@@ -7,8 +7,8 @@ discourse: true
 tutorial: scala-tour
 categories: tour
 num: 9
-tutorial-next: case-classes
-tutorial-previous: nested-functions
+next-page: case-classes
+previous-page: nested-functions
 language: pt-br
 ---
 

--- a/pt-br/tutorials/tour/_posts/2017-02-13-default-parameter-values.md
+++ b/pt-br/tutorials/tour/_posts/2017-02-13-default-parameter-values.md
@@ -7,8 +7,8 @@ discourse: true
 tutorial: scala-tour
 categories: tour
 num: 32
-tutorial-next: named-parameters
-tutorial-previous: annotations
+next-page: named-parameters
+previous-page: annotations
 language: pt-br
 ---
 

--- a/pt-br/tutorials/tour/_posts/2017-02-13-explicitly-typed-self-references.md
+++ b/pt-br/tutorials/tour/_posts/2017-02-13-explicitly-typed-self-references.md
@@ -7,8 +7,8 @@ discourse: true
 tutorial: scala-tour
 categories: tour
 num: 24
-tutorial-next: implicit-parameters
-tutorial-previous: compound-types
+next-page: implicit-parameters
+previous-page: compound-types
 language: pt-br
 ---
 

--- a/pt-br/tutorials/tour/_posts/2017-02-13-extractor-objects.md
+++ b/pt-br/tutorials/tour/_posts/2017-02-13-extractor-objects.md
@@ -7,8 +7,8 @@ discourse: true
 tutorial: scala-tour
 categories: tour
 num: 15
-tutorial-next: sequence-comprehensions
-tutorial-previous: regular-expression-patterns
+next-page: sequence-comprehensions
+previous-page: regular-expression-patterns
 language: pt-br
 ---
 

--- a/pt-br/tutorials/tour/_posts/2017-02-13-generic-classes.md
+++ b/pt-br/tutorials/tour/_posts/2017-02-13-generic-classes.md
@@ -7,8 +7,8 @@ discourse: true
 tutorial: scala-tour
 categories: tour
 num: 17
-tutorial-next: variances
-tutorial-previous: sequence-comprehensions
+next-page: variances
+previous-page: sequence-comprehensions
 language: pt-br
 ---
 

--- a/pt-br/tutorials/tour/_posts/2017-02-13-higher-order-functions.md
+++ b/pt-br/tutorials/tour/_posts/2017-02-13-higher-order-functions.md
@@ -7,8 +7,8 @@ discourse: true
 tutorial: scala-tour
 categories: tour
 num: 7
-tutorial-next: nested-functions
-tutorial-previous: anonymous-function-syntax
+next-page: nested-functions
+previous-page: anonymous-function-syntax
 language: pt-br
 ---
 

--- a/pt-br/tutorials/tour/_posts/2017-02-13-implicit-conversions.md
+++ b/pt-br/tutorials/tour/_posts/2017-02-13-implicit-conversions.md
@@ -7,8 +7,8 @@ discourse: true
 tutorial: scala-tour
 categories: tour
 num: 26
-tutorial-next: polymorphic-methods
-tutorial-previous: implicit-parameters
+next-page: polymorphic-methods
+previous-page: implicit-parameters
 language: pt-br
 ---
 

--- a/pt-br/tutorials/tour/_posts/2017-02-13-implicit-parameters.md
+++ b/pt-br/tutorials/tour/_posts/2017-02-13-implicit-parameters.md
@@ -7,8 +7,8 @@ discourse: true
 tutorial: scala-tour
 categories: tour
 num: 25
-tutorial-next: implicit-conversions
-tutorial-previous: explicitly-typed-self-references
+next-page: implicit-conversions
+previous-page: explicitly-typed-self-references
 language: pt-br
 ---
 

--- a/pt-br/tutorials/tour/_posts/2017-02-13-inner-classes.md
+++ b/pt-br/tutorials/tour/_posts/2017-02-13-inner-classes.md
@@ -7,8 +7,8 @@ discourse: true
 tutorial: scala-tour
 categories: tour
 num: 21
-tutorial-next: abstract-types
-tutorial-previous: lower-type-bounds
+next-page: abstract-types
+previous-page: lower-type-bounds
 language: pt-br
 ---
 

--- a/pt-br/tutorials/tour/_posts/2017-02-13-local-type-inference.md
+++ b/pt-br/tutorials/tour/_posts/2017-02-13-local-type-inference.md
@@ -7,8 +7,8 @@ discourse: true
 tutorial: scala-tour
 categories: tour
 num: 28
-tutorial-next: operators
-tutorial-previous: polymorphic-methods
+next-page: operators
+previous-page: polymorphic-methods
 language: pt-br
 ---
 

--- a/pt-br/tutorials/tour/_posts/2017-02-13-lower-type-bounds.md
+++ b/pt-br/tutorials/tour/_posts/2017-02-13-lower-type-bounds.md
@@ -7,8 +7,8 @@ discourse: true
 tutorial: scala-tour
 categories: tour
 num: 20
-tutorial-next: inner-classes
-tutorial-previous: upper-type-bounds
+next-page: inner-classes
+previous-page: upper-type-bounds
 language: pt-br
 ---
 

--- a/pt-br/tutorials/tour/_posts/2017-02-13-mixin-class-composition.md
+++ b/pt-br/tutorials/tour/_posts/2017-02-13-mixin-class-composition.md
@@ -7,8 +7,8 @@ discourse: true
 tutorial: scala-tour
 categories: tour
 num: 5
-tutorial-next: anonymous-function-syntax
-tutorial-previous: traits
+next-page: anonymous-function-syntax
+previous-page: traits
 language: pt-br
 ---
 _Nota de tradução: A palavra `mixin` pode ser traduzida como mescla, porém é preferível utilizar a notação original_

--- a/pt-br/tutorials/tour/_posts/2017-02-13-named-parameters.md
+++ b/pt-br/tutorials/tour/_posts/2017-02-13-named-parameters.md
@@ -7,7 +7,7 @@ discourse: true
 tutorial: scala-tour
 categories: tour
 num: 33
-tutorial-previous: default-parameter-values
+previous-page: default-parameter-values
 language: pt-br
 ---
 

--- a/pt-br/tutorials/tour/_posts/2017-02-13-nested-functions.md
+++ b/pt-br/tutorials/tour/_posts/2017-02-13-nested-functions.md
@@ -7,8 +7,8 @@ discourse: true
 tutorial: scala-tour
 categories: tour
 num: 8
-tutorial-next: currying
-tutorial-previous: higher-order-functions
+next-page: currying
+previous-page: higher-order-functions
 language: pt-br
 ---
 

--- a/pt-br/tutorials/tour/_posts/2017-02-13-operators.md
+++ b/pt-br/tutorials/tour/_posts/2017-02-13-operators.md
@@ -7,8 +7,8 @@ discourse: true
 tutorial: scala-tour
 categories: tour
 num: 29
-tutorial-next: automatic-closures
-tutorial-previous: local-type-inference
+next-page: automatic-closures
+previous-page: local-type-inference
 language: pt-br
 ---
 

--- a/pt-br/tutorials/tour/_posts/2017-02-13-pattern-matching.md
+++ b/pt-br/tutorials/tour/_posts/2017-02-13-pattern-matching.md
@@ -8,8 +8,8 @@ tutorial: scala-tour
 categories: tour
 num: 11
 
-tutorial-next: singleton-objects
-tutorial-previous: case-classes
+next-page: singleton-objects
+previous-page: case-classes
 language: pt-br
 ---
 

--- a/pt-br/tutorials/tour/_posts/2017-02-13-polymorphic-methods.md
+++ b/pt-br/tutorials/tour/_posts/2017-02-13-polymorphic-methods.md
@@ -8,8 +8,8 @@ tutorial: scala-tour
 categories: tour
 num: 27
 
-tutorial-next: local-type-inference
-tutorial-previous: implicit-conversions
+next-page: local-type-inference
+previous-page: implicit-conversions
 language: pt-br
 ---
 

--- a/pt-br/tutorials/tour/_posts/2017-02-13-regular-expression-patterns.md
+++ b/pt-br/tutorials/tour/_posts/2017-02-13-regular-expression-patterns.md
@@ -9,7 +9,7 @@ categories: tour
 num: 14
 
 tutorial-next: extractor-objects
-tutorial-previous: xml-processing
+tutorial-previous: singleton-objects
 language: pt-br
 ---
 

--- a/pt-br/tutorials/tour/_posts/2017-02-13-regular-expression-patterns.md
+++ b/pt-br/tutorials/tour/_posts/2017-02-13-regular-expression-patterns.md
@@ -8,8 +8,8 @@ tutorial: scala-tour
 categories: tour
 num: 14
 
-tutorial-next: extractor-objects
-tutorial-previous: singleton-objects
+next-page: extractor-objects
+previous-page: singleton-objects
 language: pt-br
 ---
 

--- a/pt-br/tutorials/tour/_posts/2017-02-13-sequence-comprehensions.md
+++ b/pt-br/tutorials/tour/_posts/2017-02-13-sequence-comprehensions.md
@@ -7,8 +7,8 @@ discourse: true
 tutorial: scala-tour
 categories: tour
 num: 16
-tutorial-next: generic-classes
-tutorial-previous: extractor-objects
+next-page: generic-classes
+previous-page: extractor-objects
 language: pt-br
 ---
 

--- a/pt-br/tutorials/tour/_posts/2017-02-13-singleton-objects.md
+++ b/pt-br/tutorials/tour/_posts/2017-02-13-singleton-objects.md
@@ -8,7 +8,7 @@ tutorial: scala-tour
 categories: tour
 num: 12
 
-tutorial-next: xml-processing
+tutorial-next: regular-expression-patterns
 tutorial-previous: pattern-matching
 language: pt-br
 ---

--- a/pt-br/tutorials/tour/_posts/2017-02-13-singleton-objects.md
+++ b/pt-br/tutorials/tour/_posts/2017-02-13-singleton-objects.md
@@ -8,8 +8,8 @@ tutorial: scala-tour
 categories: tour
 num: 12
 
-tutorial-next: regular-expression-patterns
-tutorial-previous: pattern-matching
+next-page: regular-expression-patterns
+previous-page: pattern-matching
 language: pt-br
 ---
 

--- a/pt-br/tutorials/tour/_posts/2017-02-13-tour-of-scala.md
+++ b/pt-br/tutorials/tour/_posts/2017-02-13-tour-of-scala.md
@@ -8,7 +8,7 @@ tutorial: scala-tour
 categories: tour
 num: 1
 outof: 33
-tutorial-next: unified-types
+next-page: unified-types
 language: pt-br
 ---
 

--- a/pt-br/tutorials/tour/_posts/2017-02-13-traits.md
+++ b/pt-br/tutorials/tour/_posts/2017-02-13-traits.md
@@ -7,8 +7,8 @@ discourse: true
 tutorial: scala-tour
 categories: tour
 num: 4
-tutorial-next: mixin-class-composition
-tutorial-previous: classes
+next-page: mixin-class-composition
+previous-page: classes
 language: pt-br
 ---
 

--- a/pt-br/tutorials/tour/_posts/2017-02-13-unified-types.md
+++ b/pt-br/tutorials/tour/_posts/2017-02-13-unified-types.md
@@ -7,8 +7,8 @@ discourse: true
 tutorial: scala-tour
 categories: tour
 num: 2
-tutorial-next: classes
-tutorial-previous: tour-of-scala
+next-page: classes
+previous-page: tour-of-scala
 language: pt-br
 ---
 

--- a/pt-br/tutorials/tour/_posts/2017-02-13-upper-type-bounds.md
+++ b/pt-br/tutorials/tour/_posts/2017-02-13-upper-type-bounds.md
@@ -7,8 +7,8 @@ discourse: true
 tutorial: scala-tour
 categories: tour
 num: 19
-tutorial-next: lower-type-bounds
-tutorial-previous: variances
+next-page: lower-type-bounds
+previous-page: variances
 language: pt-br
 ---
 

--- a/pt-br/tutorials/tour/_posts/2017-02-13-variances.md
+++ b/pt-br/tutorials/tour/_posts/2017-02-13-variances.md
@@ -7,8 +7,8 @@ discourse: true
 tutorial: scala-tour
 categories: tour
 num: 18
-tutorial-next: upper-type-bounds
-tutorial-previous: generic-classes
+next-page: upper-type-bounds
+previous-page: generic-classes
 language: pt-br
 ---
 

--- a/tutorials/tour/_posts/2017-02-13-regular-expression-patterns.md
+++ b/tutorials/tour/_posts/2017-02-13-regular-expression-patterns.md
@@ -9,7 +9,7 @@ categories: tour
 num: 15
 
 next-page: extractor-objects
-previous-page: xml-processing
+previous-page: singleton-objects
 ---
 
 Regular expressions are strings which can be used to find patterns (or lack thereof) in data. Any string can be converted to a regular expression using the `.r` method.

--- a/tutorials/tour/_posts/2017-02-13-singleton-objects.md
+++ b/tutorials/tour/_posts/2017-02-13-singleton-objects.md
@@ -8,7 +8,7 @@ tutorial: scala-tour
 categories: tour
 num: 13
 
-next-page: xml-processing
+next-page: regular-expression-patterns
 previous-page: pattern-matching
 ---
 


### PR DESCRIPTION
After the removal of the xml-processing tutorial, I realized that the next/previous links in the english tutorial tour was broken by an inexistent page, and as I fixed that, I found that the translations does not has the next/previous links too, so I decided to fix it too.