### PR TITLE
Fix class name example

### DIFF
--- a/tutorials/tour/_posts/2017-02-13-mixin-class-composition.md
+++ b/tutorials/tour/_posts/2017-02-13-mixin-class-composition.md
@@ -71,8 +71,8 @@ We would like to combine the functionality of `StringIterator` and `RichIterator
 
 ```tut
 object StringIteratorTest extends App {
-  class Iter extends StringIterator(args(0)) with RichIterator
-  val iter = new Iter
+  class RichStringIter extends StringIterator(args(0)) with RichIterator
+  val iter = new RichStringIter
   iter foreach println
 }
 ```


### PR DESCRIPTION
The class name from the text doesn't match the class name in the last example.