### PR TITLE
Tweak the `@stableABI` title to match the others

### DIFF
--- a/sips/pending/_posts/2017-01-13-binary-compatibility.md
+++ b/sips/pending/_posts/2017-01-13-binary-compatibility.md
@@ -1,6 +1,6 @@
 ---
 layout: sip
-title: SIP XX - Improving binary compatibility with @stableABI
+title: SIP-NN - Improving binary compatibility with @stableABI
 discourse: true
 ---
 


### PR DESCRIPTION
Just adjusting an outlier:

![image](https://user-images.githubusercontent.com/344610/28454811-86c8a2d6-6df4-11e7-8c28-b50a215c4c7f.png)
