### PR TITLE
Fix TOC links in documentation pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,7 +18,7 @@ keywords:
 scala-version: 2.12.0
 
 highlighter: rouge
-permalink: /:categories/:title.html
+permalink: /:categories/:title.html:output_ext
 baseurl:
 exclude: ["vendor"]
 gems:


### PR DESCRIPTION
According to https://github.com/jekyll/jekyll/issues/4145#issuecomment-158109424 `:output_ext` needs to be used to make all links generated with `page.url` contain the extension.

Fixes #819 

I haven't checked if it really works or if it breaks other links. I haven't set up jekyll right now to try out if something breaks, so maybe merge only after testing.

An alternative solution would be to configure the EPFL server to do the necessary redirecting to find documents for URLs missing the extension as explained in [the Jekyll documentation](http://jekyllrb.com/docs/permalinks/#extensionless-permalinks).