### PR TITLE
link fix

### DIFF
--- a/getting-started-sbt-track/getting-started-with-scala-and-sbt-on-the-command-line.md
+++ b/getting-started-sbt-track/getting-started-with-scala-and-sbt-on-the-command-line.md
@@ -85,4 +85,4 @@ Continue to the next tutorial in the _getting started with sbt_ series, and lear
 
 - Continue learning Scala interactively online on
  [Scala Exercises](https://www.scala-exercises.org/scala_tutorial).
-- Learn about Scala's features in bite-sized pieces by stepping through our [Tour of Scala]({{ site.baseurl }}/tour/tour-of-scala.html }).
+- Learn about Scala's features in bite-sized pieces by stepping through our [Tour of Scala]({{ site.baseurl }}/tour/tour-of-scala.html).


### PR DESCRIPTION
Extra unmatched curly brace and space character cause url to 404:
http://docs.scala-lang.org/tour/tour-of-scala.html%20%7D