### PR TITLE
Fix broken link of "Problem with this page".

### DIFF
--- a/_includes/sidebar-toc-glossary.html
+++ b/_includes/sidebar-toc-glossary.html
@@ -5,6 +5,6 @@
       <div id="toc"></div>
 		</div>
 		<hr>
-		<div class="help-us"><a href="https://github.com/scala/scala.github.com/blob/master/{{ page.relative_path }}"><i class="fa fa-pencil" aria-hidden="true"></i> Problem with this page?<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Please help us fix it!</a></div>
+		<div class="help-us"><a href="https://github.com/scala/scala.github.com/blob/master/{% if page.collection %}{{ page.relative_path }}{% else %}{{ page.path }}{% endif %}"><i class="fa fa-pencil" aria-hidden="true"></i> Problem with this page?<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Please help us fix it!</a></div>
 	</div>
 </div>

--- a/_includes/sidebar-toc-multipage-overview.html
+++ b/_includes/sidebar-toc-multipage-overview.html
@@ -46,6 +46,6 @@
       {% endif %}
 		</div>
 		<hr>
-		<div class="help-us"><a href="https://github.com/scala/scala.github.com/blob/master/{{ page.relative_path }}"><i class="fa fa-pencil" aria-hidden="true"></i> Problem with this page?<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Please help us fix it!</a></div>
+		<div class="help-us"><a href="https://github.com/scala/scala.github.com/blob/master/{% if page.collection %}{{ page.relative_path }}{% else %}{{ page.path }}{% endif %}"><i class="fa fa-pencil" aria-hidden="true"></i> Problem with this page?<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Please help us fix it!</a></div>
 	</div>
 </div>

--- a/_includes/sidebar-toc-singlepage-overview.html
+++ b/_includes/sidebar-toc-singlepage-overview.html
@@ -26,6 +26,6 @@
       {% endif %}
 		</div>
 		<hr>
-		<div class="help-us"><a href="https://github.com/scala/scala.github.com/blob/master/{{ page.relative_path }}"><i class="fa fa-pencil" aria-hidden="true"></i> Problem with this page?<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Please help us fix it!</a></div>
+		<div class="help-us"><a href="https://github.com/scala/scala.github.com/blob/master/{% if page.collection %}{{ page.relative_path }}{% else %}{{ page.path }}{% endif %}"><i class="fa fa-pencil" aria-hidden="true"></i> Problem with this page?<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Please help us fix it!</a></div>
 	</div>
 </div>

--- a/_includes/sidebar-toc-style.html
+++ b/_includes/sidebar-toc-style.html
@@ -52,7 +52,7 @@
     {% endif %}
 		</div>
 		<hr>
-		<div class="help-us"><a href="https://github.com/scala/scala.github.com/blob/master/{{ page.relative_path }}"><i class="fa fa-pencil" aria-hidden="true"></i> Problem with this page?<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Please help us fix it!</a></div>
+		<div class="help-us"><a href="https://github.com/scala/scala.github.com/blob/master/{% if page.collection %}{{ page.relative_path }}{% else %}{{ page.path }}{% endif %}"><i class="fa fa-pencil" aria-hidden="true"></i> Problem with this page?<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Please help us fix it!</a></div>
 	</div>
 </div>
 	{% endif %}

--- a/_includes/sidebar-toc-tour-overview.html
+++ b/_includes/sidebar-toc-tour-overview.html
@@ -44,6 +44,6 @@
       {% endif %}
 		</div>
 		<hr>
-		<div class="help-us"><a href="https://github.com/scala/scala.github.com/blob/master/{{ page.relative_path }}"><i class="fa fa-pencil" aria-hidden="true"></i> Problem with this page?<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Please help us fix it!</a></div>
+		<div class="help-us"><a href="https://github.com/scala/scala.github.com/blob/master/{% if page.collection %}{{ page.relative_path }}{% else %}{{ page.path }}{% endif %}"><i class="fa fa-pencil" aria-hidden="true"></i> Problem with this page?<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Please help us fix it!</a></div>
 	</div>
 </div>

--- a/_includes/sidebar-toc.html
+++ b/_includes/sidebar-toc.html
@@ -52,7 +52,7 @@
     {% endif %}
 		</div>
 		<hr>
-		<div class="help-us"><a href="https://github.com/scala/scala.github.com/blob/master/{{ page.relative_path }}"><i class="fa fa-pencil" aria-hidden="true"></i> Problem with this page?<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Please help us fix it!</a></div>
+		<div class="help-us"><a href="https://github.com/scala/scala.github.com/blob/master/{% if page.collection %}{{ page.relative_path }}{% else %}{{ page.path }}{% endif %}"><i class="fa fa-pencil" aria-hidden="true"></i> Problem with this page?<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Please help us fix it!</a></div>
 	</div>
 </div>
 	{% endif %}

--- a/_includes/tutorial-toc.html
+++ b/_includes/tutorial-toc.html
@@ -24,6 +24,6 @@
       {% include tutorial-tour-list.txt %}
 		</div>
 		<hr>
-		<div class="help-us"><a href="https://github.com/scala/scala.github.com/blob/master/{{ page.relative_path }}"><i class="fa fa-pencil" aria-hidden="true"></i> Problem with this page?<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Please help us fix it!</a></div>
+		<div class="help-us"><a href="https://github.com/scala/scala.github.com/blob/master/{% if page.collection %}{{ page.relative_path }}{% else %}{{ page.path }}{% endif %}"><i class="fa fa-pencil" aria-hidden="true"></i> Problem with this page?<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Please help us fix it!</a></div>
 	</div>
 </div>

--- a/_layouts/sip.html
+++ b/_layouts/sip.html
@@ -26,7 +26,7 @@ includeTOC: true
           <div id="toc"></div>
     		</div>
     		<hr>
-    		<div class="help-us"><a href="https://github.com/scala/scala.github.com/blob/master/{{ page.relative_path }}"><i class="fa fa-pencil" aria-hidden="true"></i> Problem with this page?<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Please help us fix it!</a></div>
+    		<div class="help-us"><a href="https://github.com/scala/scala.github.com/blob/master/{% if page.collection %}{{ page.relative_path }}{% else %}{{ page.path }}{% endif %}"><i class="fa fa-pencil" aria-hidden="true"></i> Problem with this page?<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Please help us fix it!</a></div>
     	</div>
     </div>
 

--- a/_layouts/sips.html
+++ b/_layouts/sips.html
@@ -40,7 +40,7 @@ layout: inner-page-parent-dropdown
           <li><a href="{{ site.baseurl }}/sips/sip-submission.html">Submitting a SIP</a></li>
           <li><a href="{{ site.baseurl }}/sips/sip-tutorial.html">Tutorial: Writing a SIP</a></li>
         </ul>
-    		<div class="help-us"><a href="https://github.com/scala/scala.github.com/blob/master/{{ page.relative_path }}"><i class="fa fa-pencil" aria-hidden="true"></i> Problem with this page?<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Please help us fix it!</a></div>
+    		<div class="help-us"><a href="https://github.com/scala/scala.github.com/blob/master/{% if page.collection %}{{ page.relative_path }}{% else %}{{ page.path }}{% endif %}"><i class="fa fa-pencil" aria-hidden="true"></i> Problem with this page?<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Please help us fix it!</a></div>
     	</div>
     </div>
 


### PR DESCRIPTION
I found there are some broken links in "Problem with this page?" of right sidebar.

For example, http://docs.scala-lang.org/glossary/index.html and http://docs.scala-lang.org/api/all.html.

Those pages would get empty from `page.relative_path`, due to not all pages or markdowns in collection.

After I did some research, I found out this [comment](https://github.com/jekyll/jekyll/issues/2897#issuecomment-55149803), the author proposed this [walkaround solution](https://github.com/jekyll/jekyll/issues/2897#issuecomment-55157824).

So I replaced `page.relative_path` to this solution. I am not sure there is better solution or not. If there is a better solution, please just close it. : )